### PR TITLE
refactor(deps): update `github.com/xanzy/go-gitlab` import to `gitlab.com/gitlab-org/api/client-go`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,7 +6,7 @@ linters:
     - dogsled
     - durationcheck
     - errcheck
-    - exportloopref
+    - copyloopvar
     - govet
     - gosimple
     - gofmt

--- a/README.md
+++ b/README.md
@@ -33,9 +33,8 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/xanzy/go-gitlab"
-
 	"github.com/flc1125/go-gitlab-webhook"
+	"gitlab.com/gitlab-org/api/client-go"
 )
 
 var (

--- a/dispatcher.go
+++ b/dispatcher.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/xanzy/go-gitlab"
+	gitlab "gitlab.com/gitlab-org/api/client-go"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/dispatcher_test.go
+++ b/dispatcher_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/xanzy/go-gitlab"
+	gitlab "gitlab.com/gitlab-org/api/client-go"
 )
 
 type dispatcherContextKey struct{}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/stretchr/testify v1.10.0
-	github.com/xanzy/go-gitlab v0.115.0
+	gitlab.com/gitlab-org/api/client-go v0.116.0
 	golang.org/x/sync v0.10.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/xanzy/go-gitlab v0.115.0 h1:6DmtItNcVe+At/liXSgfE/DZNZrGfalQmBRmOcJjOn8=
-github.com/xanzy/go-gitlab v0.115.0/go.mod h1:5XCDtM7AM6WMKmfDdOiEpyRWUqui2iS9ILfvCZ2gJ5M=
+gitlab.com/gitlab-org/api/client-go v0.116.0 h1:Dy534gtZPMrnm3fAcmQRMadrcoUyFO4FQ4rXlSAdHAw=
+gitlab.com/gitlab-org/api/client-go v0.116.0/go.mod h1:B29OfnZklmaoiR7uHANh9jTyfWEgmXvZLVEnosw2Dx0=
 golang.org/x/oauth2 v0.22.0 h1:BzDx2FehcG7jJwgWLELCdmLuxk2i+x9UDpSiss2u0ZA=
 golang.org/x/oauth2 v0.22.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
 golang.org/x/sync v0.10.0 h1:3NQrjDixjgGwUOCaF8w2+VYHv0Ve/vGYSbdkTa98gmQ=

--- a/listeners.go
+++ b/listeners.go
@@ -3,7 +3,7 @@ package gitlabwebhook
 import (
 	"context"
 
-	"github.com/xanzy/go-gitlab"
+	gitlab "gitlab.com/gitlab-org/api/client-go"
 )
 
 type BuildListener interface {

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,18 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "labels": ["dependencies"],
+  "separateMajorMinor": true,
+  "postUpdateOptions": ["gomodTidy"],
+  "constraints": {
+    "go": "1.18"
+  },
+  "packageRules": [
+    {
+      "matchManagers": ["gomod"],
+      "matchDepTypes": ["indirect"],
+      "enabled": true
+    }
   ]
 }


### PR DESCRIPTION
closed https://github.com/flc1125/go-gitlab-webhook/issues/19

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated import statements for the GitLab client library throughout the project to utilize a new dependency.
	- Enhanced configuration in `renovate.json` for dependency management, including new fields for labeling and version constraints.

- **Bug Fixes**
	- Ensured all event processing methods continue to function correctly with the updated GitLab client library.

- **Documentation**
	- Revised `README.md` to reflect the new import path for the GitLab client library.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->