### PR TITLE
build(go.mod): update module go version to 1.21

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     name: "go test"
     strategy:
       matrix:
-        go-version: [ 1.18.x, 1.19.x, 1.20.x, 1.21.x, 1.22.x, 1.23.x ]
+        go-version: [ 1.21.x, 1.22.x, 1.23.x ]
         platform: [ ubuntu-latest, windows-latest, macos-latest ]
     runs-on: ${{ matrix.platform }}
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Gitlab Webhook Dispatcher 🚀
 
-![Supported Go Versions](https://img.shields.io/badge/Go-%3E%3D1.18-blue)
+![Supported Go Versions](https://img.shields.io/badge/Go-%3E%3D1.21-blue)
 [![Package Version](https://badgen.net/github/release/flc1125/go-gitlab-webhook/stable)](https://github.com/flc1125/go-gitlab-webhook/releases)
 [![GoDoc](https://pkg.go.dev/badge/github.com/flc1125/go-gitlab-webhook)](https://pkg.go.dev/github.com/flc1125/go-gitlab-webhook)
 [![codecov](https://codecov.io/gh/flc1125/go-gitlab-webhook/graph/badge.svg?token=QPTHZ5L9GT)](https://codecov.io/gh/flc1125/go-gitlab-webhook)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/flc1125/go-gitlab-webhook
 
-go 1.18
+go 1.21
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,7 @@
   "separateMajorMinor": true,
   "postUpdateOptions": ["gomodTidy"],
   "constraints": {
-    "go": "1.18"
+    "go": "1.21"
   },
   "packageRules": [
     {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the minimum required Go version to 1.21 across project documentation and configuration files.
  
- **Documentation**
	- Modified the README file to reflect the updated Go version badge.

- **Chores**
	- Updated configuration files to specify the new Go version (go.mod, renovate.json).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->