### PR TITLE
build(mod): update module path to v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Supported Go Versions](https://img.shields.io/badge/Go-%3E%3D1.21-blue)
 [![Package Version](https://badgen.net/github/release/flc1125/go-gitlab-webhook/stable)](https://github.com/flc1125/go-gitlab-webhook/releases)
-[![GoDoc](https://pkg.go.dev/badge/github.com/flc1125/go-gitlab-webhook)](https://pkg.go.dev/github.com/flc1125/go-gitlab-webhook)
+[![GoDoc](https://pkg.go.dev/badge/github.com/flc1125/go-gitlab-webhook/v2)](https://pkg.go.dev/github.com/flc1125/go-gitlab-webhook/v2)
 [![codecov](https://codecov.io/gh/flc1125/go-gitlab-webhook/graph/badge.svg?token=QPTHZ5L9GT)](https://codecov.io/gh/flc1125/go-gitlab-webhook)
 [![Go Report Card](https://goreportcard.com/badge/github.com/flc1125/go-gitlab-webhook)](https://goreportcard.com/report/github.com/flc1125/go-gitlab-webhook)
 [![lint](https://github.com/flc1125/go-gitlab-webhook/actions/workflows/lint.yml/badge.svg)](https://github.com/flc1125/go-gitlab-webhook/actions/workflows/lint.yml)
@@ -21,7 +21,7 @@ This is a simple webhook dispatcher for Gitlab. It listens for incoming webhooks
 ## 📦 Installation
 
 ```shell
-go get github.com/flc1125/go-gitlab-webhook
+go get github.com/flc1125/go-gitlab-webhook/v2
 ```
 
 ## 💻 Usage
@@ -33,7 +33,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/flc1125/go-gitlab-webhook"
+	"github.com/flc1125/go-gitlab-webhook/v2"
 	"gitlab.com/gitlab-org/api/client-go"
 )
 
@@ -108,5 +108,5 @@ MIT License. See [LICENSE](LICENSE) for the full license text.
 
 ## 💖 Thanks
 
-- [xanzy/go-gitlab](https://github.com/xanzy/go-gitlab): Go library for accessing the GitLab API
+- [gitlab-org/api/client-go](https://gitlab.com/gitlab-org/api/client-go)(Formerly known as: [xanzy/go-gitlab](https://github.com/xanzy/go-gitlab)): Go library for accessing the GitLab API
 - [stretchr/testify](github.com/stretchr/testify): A toolkit with common assertions and mocks that plays nicely with the standard library

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/flc1125/go-gitlab-webhook
+module github.com/flc1125/go-gitlab-webhook/v2
 
 go 1.21
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated GoDoc badge URL to reflect the new major version.
	- Revised installation command to use the new package version.
	- Adjusted import statement in usage examples to the new package version.
	- Updated acknowledgment of the GitLab API client library to its new repository location.

- **Chores**
	- Updated module declaration to indicate the new version of the package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->