### PR TITLE
chore(renovate): update Go constraint to 1.22.10

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,7 @@
   "separateMajorMinor": true,
   "postUpdateOptions": ["gomodTidy"],
   "constraints": {
-    "go": "1.21"
+    "go": "1.22.10"
   },
   "packageRules": [
     {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated Go language version constraint to 1.22.10 in project dependency management configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->