### PR TITLE
chore: upgrade go version to 1.23

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,6 +16,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: stable
+          go-version: 1.23.x
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     name: "go test"
     strategy:
       matrix:
-        go-version: [ 1.22.x, 1.23.x, 1.24.x ]
+        go-version: [ 1.23.x, 1.24.x ]
         platform: [ ubuntu-latest, windows-latest, macos-latest ]
     runs-on: ${{ matrix.platform }}
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Gitlab Webhook Dispatcher 🚀
 
-![Supported Go Versions](https://img.shields.io/badge/Go-%3E%3D1.22.10-blue)
+![Supported Go Versions](https://img.shields.io/badge/Go-%3E%3D1.23-blue)
 [![Package Version](https://badgen.net/github/release/flc1125/go-gitlab-webhook/stable)](https://github.com/flc1125/go-gitlab-webhook/releases)
 [![GoDoc](https://pkg.go.dev/badge/github.com/flc1125/go-gitlab-webhook/v2)](https://pkg.go.dev/github.com/flc1125/go-gitlab-webhook/v2)
 [![codecov](https://codecov.io/gh/flc1125/go-gitlab-webhook/graph/badge.svg?token=QPTHZ5L9GT)](https://codecov.io/gh/flc1125/go-gitlab-webhook)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/flc1125/go-gitlab-webhook/v2
 
-go 1.22.10
+go 1.23
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,7 @@
   "separateMajorMinor": true,
   "postUpdateOptions": ["gomodTidy"],
   "constraints": {
-    "go": "1.22.10"
+    "go": "1.23"
   },
   "packageRules": [
     {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the Go language settings across automation and dependency configurations to require Go 1.23 and above, including adjustments to testing parameters.
- **Documentation**
  - Revised the public-facing version badge to reflect the new Go version support, ensuring users see the current minimum requirement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->