### PR TITLE
refactor(dispatcher): replace `errgroup` with `sync.WaitGroup` for event processing

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -3,10 +3,10 @@ name: Go Static Analysis
 on:
   push:
     branches:
-      - master
+      - v1.x
   pull_request:
     branches:
-      - master
+      - v1.x
 
 jobs:
   golangci:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,10 +3,10 @@ name: Go Lint
 on:
   push:
     branches:
-      - master
+      - v1.x
   pull_request:
     branches:
-      - master
+      - v1.x
 
 jobs:
   golangci:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     name: "go test"
     strategy:
       matrix:
-        go-version: [ 1.18.x, 1.19.x, 1.20.x, 1.21.x, 1.22.x, 1.23.x, 1.24.x ]
+        go-version: [ 1.23.x, 1.24.x ]
         platform: [ ubuntu-latest, windows-latest, macos-latest ]
     runs-on: ${{ matrix.platform }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,10 +2,10 @@ name: Go Test
 on:
   push:
     branches:
-      - master
+      - v1.x
   pull_request:
     branches:
-      - master
+      - v1.x
 env:
   GOPROXY: "https://proxy.golang.org"
 
@@ -14,7 +14,7 @@ jobs:
     name: "go test"
     strategy:
       matrix:
-        go-version: [ 1.18.x, 1.19.x, 1.20.x, 1.21.x, 1.22.x, 1.23.x ]
+        go-version: [ 1.18.x, 1.19.x, 1.20.x, 1.21.x, 1.22.x, 1.23.x, 1.24.x ]
         platform: [ ubuntu-latest, windows-latest, macos-latest ]
     runs-on: ${{ matrix.platform }}
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,7 +6,7 @@ linters:
     - dogsled
     - durationcheck
     - errcheck
-    - exportloopref
+    - copyloopvar
     - govet
     - gosimple
     - gofmt

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,7 +16,6 @@ linters:
     - mnd
     - gocyclo
     - ineffassign
-    - lll
     - prealloc
     - revive
     - staticcheck

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Gitlab Webhook Dispatcher 🚀
 
-![Supported Go Versions](https://img.shields.io/badge/Go-%3E%3D1.18-blue)
+![Supported Go Versions](https://img.shields.io/badge/Go-%3E%3D1.23-blue)
 [![Package Version](https://badgen.net/github/release/flc1125/go-gitlab-webhook/stable)](https://github.com/flc1125/go-gitlab-webhook/releases)
 [![GoDoc](https://pkg.go.dev/badge/github.com/flc1125/go-gitlab-webhook)](https://pkg.go.dev/github.com/flc1125/go-gitlab-webhook)
 [![codecov](https://codecov.io/gh/flc1125/go-gitlab-webhook/graph/badge.svg?token=QPTHZ5L9GT)](https://codecov.io/gh/flc1125/go-gitlab-webhook)

--- a/dispatcher.go
+++ b/dispatcher.go
@@ -417,7 +417,6 @@ func process[L any, E any](listeners []L, event E, handler func(L, E) error) err
 
 	errCh := make(chan error, len(listeners))
 	for _, listener := range listeners {
-		listener := listener
 		go func() {
 			defer wg.Done()
 			if err := handler(listener, event); err != nil {

--- a/dispatcher.go
+++ b/dispatcher.go
@@ -5,9 +5,9 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"sync"
 
 	"github.com/xanzy/go-gitlab"
-	"golang.org/x/sync/errgroup"
 )
 
 var ErrUnsupportedEvent = errors.New("gitlab-webhook: unsupported event type")
@@ -286,210 +286,153 @@ func (d *Dispatcher) DispatchRequest(req *http.Request, opts ...DispatchRequestO
 }
 
 func (d *Dispatcher) processBuildEvent(ctx context.Context, event *gitlab.BuildEvent) error {
-	eg, ctx := errgroup.WithContext(ctx)
-	for _, listener := range d.buildListeners {
-		listener := listener
-		eg.Go(func() error {
-			return listener.OnBuild(ctx, event)
-		})
-	}
-	return eg.Wait()
+	return process(d.buildListeners, event, func(listener BuildListener, event *gitlab.BuildEvent) error {
+		return listener.OnBuild(ctx, event)
+	})
 }
 
 func (d *Dispatcher) processCommitCommentEvent(ctx context.Context, event *gitlab.CommitCommentEvent) error {
-	eg, ctx := errgroup.WithContext(ctx)
-	for _, listener := range d.commitCommentListeners {
-		listener := listener
-		eg.Go(func() error {
-			return listener.OnCommitComment(ctx, event)
-		})
-	}
-	return eg.Wait()
+	return process(d.commitCommentListeners, event, func(listener CommitCommentListener, event *gitlab.CommitCommentEvent) error {
+		return listener.OnCommitComment(ctx, event)
+	})
 }
 
 func (d *Dispatcher) processDeploymentEvent(ctx context.Context, event *gitlab.DeploymentEvent) error {
-	eg, ctx := errgroup.WithContext(ctx)
-	for _, listener := range d.deploymentListeners {
-		listener := listener
-		eg.Go(func() error {
-			return listener.OnDeployment(ctx, event)
-		})
-	}
-	return eg.Wait()
+	return process(d.deploymentListeners, event, func(listener DeploymentListener, event *gitlab.DeploymentEvent) error {
+		return listener.OnDeployment(ctx, event)
+	})
 }
 
 func (d *Dispatcher) processFeatureFlagEvent(ctx context.Context, event *gitlab.FeatureFlagEvent) error {
-	eg, ctx := errgroup.WithContext(ctx)
-	for _, listener := range d.featureFlagListeners {
-		listener := listener
-		eg.Go(func() error {
-			return listener.OnFeatureFlag(ctx, event)
-		})
-	}
-	return eg.Wait()
+	return process(d.featureFlagListeners, event, func(listener FeatureFlagListener, event *gitlab.FeatureFlagEvent) error {
+		return listener.OnFeatureFlag(ctx, event)
+	})
 }
 
 func (d *Dispatcher) processGroupResourceAccessTokenEvent(ctx context.Context, event *gitlab.GroupResourceAccessTokenEvent) error { //nolint:lll
-	eg, ctx := errgroup.WithContext(ctx)
-	for _, listener := range d.groupResourceAccessTokenListeners {
-		listener := listener
-		eg.Go(func() error {
-			return listener.OnGroupResourceAccessToken(ctx, event)
-		})
-	}
-	return eg.Wait()
+	return process(d.groupResourceAccessTokenListeners, event, func(listener GroupResourceAccessTokenListener, event *gitlab.GroupResourceAccessTokenEvent) error {
+		return listener.OnGroupResourceAccessToken(ctx, event)
+	})
 }
 
 func (d *Dispatcher) processIssueCommentEvent(ctx context.Context, event *gitlab.IssueCommentEvent) error {
-	eg, ctx := errgroup.WithContext(ctx)
-	for _, listener := range d.issueCommentListeners {
-		listener := listener
-		eg.Go(func() error {
-			return listener.OnIssueComment(ctx, event)
-		})
-	}
-	return eg.Wait()
+	return process(d.issueCommentListeners, event, func(listener IssueCommentListener, event *gitlab.IssueCommentEvent) error {
+		return listener.OnIssueComment(ctx, event)
+	})
 }
 
 func (d *Dispatcher) processIssueEvent(ctx context.Context, event *gitlab.IssueEvent) error {
-	eg, ctx := errgroup.WithContext(ctx)
-	for _, listener := range d.issueListeners {
-		listener := listener
-		eg.Go(func() error {
-			return listener.OnIssue(ctx, event)
-		})
-	}
-	return eg.Wait()
+	return process(d.issueListeners, event, func(listener IssueListener, event *gitlab.IssueEvent) error {
+		return listener.OnIssue(ctx, event)
+	})
 }
 
 func (d *Dispatcher) processJobEvent(ctx context.Context, event *gitlab.JobEvent) error {
-	eg, ctx := errgroup.WithContext(ctx)
-	for _, listener := range d.jobListeners {
-		listener := listener
-		eg.Go(func() error {
-			return listener.OnJob(ctx, event)
-		})
-	}
-	return eg.Wait()
+	return process(d.jobListeners, event, func(listener JobListener, event *gitlab.JobEvent) error {
+		return listener.OnJob(ctx, event)
+	})
 }
 
 func (d *Dispatcher) processMemberEvent(ctx context.Context, event *gitlab.MemberEvent) error {
-	eg, ctx := errgroup.WithContext(ctx)
-	for _, listener := range d.memberListeners {
-		listener := listener
-		eg.Go(func() error {
-			return listener.OnMember(ctx, event)
-		})
-	}
-	return eg.Wait()
+	return process(d.memberListeners, event, func(listener MemberListener, event *gitlab.MemberEvent) error {
+		return listener.OnMember(ctx, event)
+	})
 }
 
 func (d *Dispatcher) processMergeCommentEvent(ctx context.Context, event *gitlab.MergeCommentEvent) error {
-	eg, ctx := errgroup.WithContext(ctx)
-	for _, listener := range d.mergeCommentListeners {
-		listener := listener
-		eg.Go(func() error {
-			return listener.OnMergeComment(ctx, event)
-		})
-	}
-	return eg.Wait()
+	return process(d.mergeCommentListeners, event, func(listener MergeCommentListener, event *gitlab.MergeCommentEvent) error {
+		return listener.OnMergeComment(ctx, event)
+	})
 }
 
 func (d *Dispatcher) processMergeEvent(ctx context.Context, event *gitlab.MergeEvent) error {
-	eg, ctx := errgroup.WithContext(ctx)
-	for _, listener := range d.mergeListeners {
-		listener := listener
-		eg.Go(func() error {
-			return listener.OnMerge(ctx, event)
-		})
-	}
-	return eg.Wait()
+	return process(d.mergeListeners, event, func(listener MergeListener, event *gitlab.MergeEvent) error {
+		return listener.OnMerge(ctx, event)
+	})
 }
 
 func (d *Dispatcher) processPipelineEvent(ctx context.Context, event *gitlab.PipelineEvent) error {
-	eg, ctx := errgroup.WithContext(ctx)
-	for _, listener := range d.pipelineListeners {
-		listener := listener
-		eg.Go(func() error {
-			return listener.OnPipeline(ctx, event)
-		})
-	}
-	return eg.Wait()
+	return process(d.pipelineListeners, event, func(listener PipelineListener, event *gitlab.PipelineEvent) error {
+		return listener.OnPipeline(ctx, event)
+	})
 }
 
 func (d *Dispatcher) processProjectResourceAccessTokenEvent(ctx context.Context, event *gitlab.ProjectResourceAccessTokenEvent) error { //nolint:lll
-	eg, ctx := errgroup.WithContext(ctx)
-	for _, listener := range d.projectResourceAccessTokenListeners {
-		listener := listener
-		eg.Go(func() error {
-			return listener.OnProjectResourceAccessToken(ctx, event)
-		})
-	}
-	return eg.Wait()
+	return process(d.projectResourceAccessTokenListeners, event, func(listener ProjectResourceAccessTokenListener, event *gitlab.ProjectResourceAccessTokenEvent) error {
+		return listener.OnProjectResourceAccessToken(ctx, event)
+	})
 }
 
 func (d *Dispatcher) processPushEvent(ctx context.Context, event *gitlab.PushEvent) error {
-	eg, ctx := errgroup.WithContext(ctx)
-	for _, listener := range d.pushListeners {
-		listener := listener
-		eg.Go(func() error {
-			return listener.OnPush(ctx, event)
-		})
-	}
-	return eg.Wait()
+	return process(d.pushListeners, event, func(listener PushListener, event *gitlab.PushEvent) error {
+		return listener.OnPush(ctx, event)
+	})
 }
 
 func (d *Dispatcher) processReleaseEvent(ctx context.Context, event *gitlab.ReleaseEvent) error {
-	eg, ctx := errgroup.WithContext(ctx)
-	for _, listener := range d.releaseListeners {
-		listener := listener
-		eg.Go(func() error {
-			return listener.OnRelease(ctx, event)
-		})
-	}
-	return eg.Wait()
+	return process(d.releaseListeners, event, func(listener ReleaseListener, event *gitlab.ReleaseEvent) error {
+		return listener.OnRelease(ctx, event)
+	})
 }
 
 func (d *Dispatcher) processSnippetCommentEvent(ctx context.Context, event *gitlab.SnippetCommentEvent) error {
-	eg, ctx := errgroup.WithContext(ctx)
-	for _, listener := range d.snippetCommentListeners {
-		listener := listener
-		eg.Go(func() error {
-			return listener.OnSnippetComment(ctx, event)
-		})
-	}
-	return eg.Wait()
+	return process(d.snippetCommentListeners, event, func(listener SnippetCommentListener, event *gitlab.SnippetCommentEvent) error {
+		return listener.OnSnippetComment(ctx, event)
+	})
 }
 
 func (d *Dispatcher) processSubGroupEvent(ctx context.Context, event *gitlab.SubGroupEvent) error {
-	eg, ctx := errgroup.WithContext(ctx)
-	for _, listener := range d.subGroupListeners {
-		listener := listener
-		eg.Go(func() error {
-			return listener.OnSubGroup(ctx, event)
-		})
-	}
-	return eg.Wait()
+	return process(d.subGroupListeners, event, func(listener SubGroupListener, event *gitlab.SubGroupEvent) error {
+		return listener.OnSubGroup(ctx, event)
+	})
 }
 
 func (d *Dispatcher) processTagEvent(ctx context.Context, event *gitlab.TagEvent) error {
-	eg, ctx := errgroup.WithContext(ctx)
-	for _, listener := range d.tagListeners {
-		listener := listener
-		eg.Go(func() error {
-			return listener.OnTag(ctx, event)
-		})
-	}
-	return eg.Wait()
+	return process(d.tagListeners, event, func(listener TagListener, event *gitlab.TagEvent) error {
+		return listener.OnTag(ctx, event)
+	})
 }
 
 func (d *Dispatcher) processWikiPageEvent(ctx context.Context, event *gitlab.WikiPageEvent) error {
-	eg, ctx := errgroup.WithContext(ctx)
-	for _, listener := range d.wikiPageListeners {
-		listener := listener
-		eg.Go(func() error {
-			return listener.OnWikiPage(ctx, event)
-		})
+	return process(d.wikiPageListeners, event, func(listener WikiPageListener, event *gitlab.WikiPageEvent) error {
+		return listener.OnWikiPage(ctx, event)
+	})
+}
+
+var waitGroupPool = sync.Pool{
+	New: func() any {
+		return &sync.WaitGroup{}
+	},
+}
+
+func process[L any, E any](listeners []L, event E, handler func(L, E) error) error {
+	if len(listeners) == 0 {
+		return nil
 	}
-	return eg.Wait()
+	wg := waitGroupPool.Get().(*sync.WaitGroup)
+	wg.Add(len(listeners))
+	defer func() {
+		waitGroupPool.Put(wg)
+	}()
+
+	errCh := make(chan error, len(listeners))
+	for _, listener := range listeners {
+		listener := listener
+		go func() {
+			defer wg.Done()
+			if err := handler(listener, event); err != nil {
+				errCh <- err
+			}
+		}()
+	}
+	wg.Wait()
+
+	close(errCh)
+	var err error
+	for e := range errCh {
+		if e != nil {
+			err = errors.Join(err, e)
+		}
+	}
+	return err
 }

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.18
 require (
 	github.com/stretchr/testify v1.10.0
 	github.com/xanzy/go-gitlab v0.115.0
-	golang.org/x/sync v0.10.0
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/flc1125/go-gitlab-webhook
 
-go 1.18
+go 1.23
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,6 @@ github.com/xanzy/go-gitlab v0.115.0 h1:6DmtItNcVe+At/liXSgfE/DZNZrGfalQmBRmOcJjO
 github.com/xanzy/go-gitlab v0.115.0/go.mod h1:5XCDtM7AM6WMKmfDdOiEpyRWUqui2iS9ILfvCZ2gJ5M=
 golang.org/x/oauth2 v0.22.0 h1:BzDx2FehcG7jJwgWLELCdmLuxk2i+x9UDpSiss2u0ZA=
 golang.org/x/oauth2 v0.22.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
-golang.org/x/sync v0.10.0 h1:3NQrjDixjgGwUOCaF8w2+VYHv0Ve/vGYSbdkTa98gmQ=
-golang.org/x/sync v0.10.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.24.0 h1:Twjiwq9dn6R1fQcyiK+wQyHWfaz/BJB+YIpzU/Cv3Xg=
 golang.org/x/sys v0.24.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/time v0.6.0 h1:eTDhh4ZXt5Qf0augr54TN6suAUudPcawVZeIAPU7D4U=


### PR DESCRIPTION
- Remove dependency on golang.org/x/sync
- Implement generic process function for event handling
- Update all event processing methods to use the new process function
- Add waitGroupPool for efficient WaitGroup reuse
- Improve error handling and reporting