### PR TITLE
ci: update Go version to 1.24.0

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,6 +16,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.23.x
+          go-version: 1.24.x
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     name: "go test"
     strategy:
       matrix:
-        go-version: [ 1.23.x, 1.24.x ]
+        go-version: [ 1.24.x, 1.25.x ]
         platform: [ ubuntu-latest, windows-latest, macos-latest ]
     runs-on: ${{ matrix.platform }}
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Gitlab Webhook Dispatcher 🚀
 
-![Supported Go Versions](https://img.shields.io/badge/Go-%3E%3D1.23.0-blue)
+![Supported Go Versions](https://img.shields.io/badge/Go-%3E%3D1.24.0-blue)
 [![Package Version](https://badgen.net/github/release/flc1125/go-gitlab-webhook/stable)](https://github.com/flc1125/go-gitlab-webhook/releases)
 [![GoDoc](https://pkg.go.dev/badge/github.com/flc1125/go-gitlab-webhook/v2)](https://pkg.go.dev/github.com/flc1125/go-gitlab-webhook/v2)
 [![codecov](https://codecov.io/gh/flc1125/go-gitlab-webhook/graph/badge.svg?token=QPTHZ5L9GT)](https://codecov.io/gh/flc1125/go-gitlab-webhook)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/flc1125/go-gitlab-webhook/v2
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,7 @@
   "separateMajorMinor": true,
   "postUpdateOptions": ["gomodTidy"],
   "constraints": {
-    "go": "1.23.0"
+    "go": "1.24.0"
   },
   "packageRules": [
     {


### PR DESCRIPTION
- Update Go version in go.mod from 1.23.0 to 1.24.0
- Update Go version in GitHub Actions workflows from1.23.x to 1.24.x
- Update supported Go version in README.md from 1.23.0 to 1.24.0
- Update Go version constraint in renovate.json from 1.23.0 to 1.24.0
- Update Go version matrix in test.yml to include 1.24.x and 1.25.x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated README badge to reflect support for Go >= 1.24.

- Tests
  - CI now tests against Go 1.24.x and 1.25.x.

- Chores
  - Upgraded project toolchain and configs to Go 1.24.
  - Updated lint workflow to use Go 1.24.x.
  - Adjusted dependency update settings to target Go 1.24.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->