### PR TITLE
feat(gitlab-webhook): add token validation for webhook requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This is a simple webhook dispatcher for Gitlab. It listens for incoming webhooks
 - 🔄 A single listener can implement multiple different webhook functions
 - ⚡ Support asynchronous and efficient processing
 - 🚀 Multiple dispatch methods
+- 🔐 Token validation support for secure webhook handling
 
 ## 📦 Installation
 
@@ -87,6 +88,7 @@ func main() {
 
 	http.Handle("/webhook", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if err := dispatcher.DispatchRequest(r,
+			gitlabwebhook.DispatchRequestWithToken("your-secret-token"), // validate token, if needed
 			gitlabwebhook.DispatchRequestWithContext(context.Background()), // custom context
 		); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/dispatcher.go
+++ b/dispatcher.go
@@ -2,6 +2,7 @@ package gitlabwebhook
 
 import (
 	"context"
+	"crypto/subtle"
 	"errors"
 	"io"
 	"net/http"
@@ -292,7 +293,8 @@ func (d *Dispatcher) DispatchRequest(req *http.Request, opts ...DispatchRequestO
 	// check token if provided
 	if o.token != "" {
 		token := req.Header.Get("X-Gitlab-Token")
-		if token != o.token {
+		// constant time compare to prevent timing attacks on token comparison
+		if subtle.ConstantTimeCompare([]byte(token), []byte(o.token)) != 1 {
 			return ErrInvalidToken
 		}
 	}

--- a/dispatcher.go
+++ b/dispatcher.go
@@ -10,7 +10,10 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-var ErrUnsupportedEvent = errors.New("gitlab-webhook: unsupported event type")
+var (
+	ErrUnsupportedEvent = errors.New("gitlab-webhook: unsupported event type")
+	ErrInvalidToken     = errors.New("gitlab-webhook: invalid token")
+)
 
 type Dispatcher struct {
 	buildListeners                      []BuildListener
@@ -260,7 +263,8 @@ func (d *Dispatcher) DispatchWebhook(ctx context.Context, eventType gitlab.Event
 }
 
 type dispatchRequestOptions struct {
-	ctx context.Context
+	ctx   context.Context
+	token string
 }
 
 type DispatchRequestOption func(*dispatchRequestOptions)
@@ -271,6 +275,12 @@ func DispatchRequestWithContext(ctx context.Context) DispatchRequestOption {
 	}
 }
 
+func DispatchRequestWithToken(token string) DispatchRequestOption {
+	return func(o *dispatchRequestOptions) {
+		o.token = token
+	}
+}
+
 func (d *Dispatcher) DispatchRequest(req *http.Request, opts ...DispatchRequestOption) error {
 	o := &dispatchRequestOptions{
 		ctx: req.Context(),
@@ -278,10 +288,22 @@ func (d *Dispatcher) DispatchRequest(req *http.Request, opts ...DispatchRequestO
 	for _, opt := range opts {
 		opt(o)
 	}
+
+	// check token if provided
+	if o.token != "" {
+		token := req.Header.Get("X-Gitlab-Token")
+		if token != o.token {
+			return ErrInvalidToken
+		}
+	}
+
+	// read payload
 	payload, err := io.ReadAll(req.Body)
 	if err != nil {
 		return err
 	}
+
+	// dispatch webhook
 	return d.DispatchWebhook(o.ctx, gitlab.HookEventType(req), payload)
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added token-based validation for webhook requests to verify authenticity before processing.

* **Documentation**
  * Updated docs and examples to show how to provide an optional token for request validation.

* **Tests**
  * Added tests covering valid tokens, invalid tokens, missing tokens, and successful dispatch when no token is configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->