### PR TITLE
Add EmojiEvent dispatcher support

### DIFF
--- a/dispatcher.go
+++ b/dispatcher.go
@@ -20,6 +20,7 @@ type Dispatcher struct {
 	buildListeners                      []BuildListener
 	commitCommentListeners              []CommitCommentListener
 	deploymentListeners                 []DeploymentListener
+	emojiListeners                      []EmojiListener
 	featureFlagListeners                []FeatureFlagListener
 	groupResourceAccessTokenListeners   []GroupResourceAccessTokenListener
 	issueCommentListeners               []IssueCommentListener
@@ -66,6 +67,10 @@ func (d *Dispatcher) RegisterListeners(listeners ...any) {
 
 		if l, ok := listener.(DeploymentListener); ok {
 			d.RegisterDeploymentListener(l)
+		}
+
+		if l, ok := listener.(EmojiListener); ok {
+			d.RegisterEmojiListener(l)
 		}
 
 		if l, ok := listener.(FeatureFlagListener); ok {
@@ -146,6 +151,10 @@ func (d *Dispatcher) RegisterDeploymentListener(listeners ...DeploymentListener)
 	d.deploymentListeners = append(d.deploymentListeners, listeners...)
 }
 
+func (d *Dispatcher) RegisterEmojiListener(listeners ...EmojiListener) {
+	d.emojiListeners = append(d.emojiListeners, listeners...)
+}
+
 func (d *Dispatcher) RegisterFeatureFlagListener(listeners ...FeatureFlagListener) {
 	d.featureFlagListeners = append(d.featureFlagListeners, listeners...)
 }
@@ -218,6 +227,8 @@ func (d *Dispatcher) Dispatch(ctx context.Context, event any) error {
 		return d.processCommitCommentEvent(ctx, e)
 	case *gitlab.DeploymentEvent:
 		return d.processDeploymentEvent(ctx, e)
+	case *gitlab.EmojiEvent:
+		return d.processEmojiEvent(ctx, e)
 	case *gitlab.FeatureFlagEvent:
 		return d.processFeatureFlagEvent(ctx, e)
 	case *gitlab.GroupResourceAccessTokenEvent:
@@ -319,6 +330,10 @@ func (d *Dispatcher) processCommitCommentEvent(ctx context.Context, event *gitla
 
 func (d *Dispatcher) processDeploymentEvent(ctx context.Context, event *gitlab.DeploymentEvent) error {
 	return processEvent(ctx, d.deploymentListeners, DeploymentListener.OnDeployment, event)
+}
+
+func (d *Dispatcher) processEmojiEvent(ctx context.Context, event *gitlab.EmojiEvent) error {
+	return processEvent(ctx, d.emojiListeners, EmojiListener.OnEmoji, event)
 }
 
 func (d *Dispatcher) processFeatureFlagEvent(ctx context.Context, event *gitlab.FeatureFlagEvent) error {

--- a/dispatcher_test.go
+++ b/dispatcher_test.go
@@ -49,9 +49,9 @@ func TestDispatcher_Dispatch(t *testing.T) {
 		eventType gitlab.EventType
 		filepath  string
 	}{
-		{"build", gitlab.EventTypeBuild, "testdata/webhooks/build.json"},                                                           //nolint:lll
-		{"commit comment", gitlab.EventTypeNote, "testdata/webhooks/note_commit.json"},                                             //nolint:lll
-		{"deployment", gitlab.EventTypeDeployment, "testdata/webhooks/deployment.json"},                                            //nolint:lll
+		{"build", gitlab.EventTypeBuild, "testdata/webhooks/build.json"},                //nolint:lll
+		{"commit comment", gitlab.EventTypeNote, "testdata/webhooks/note_commit.json"},  //nolint:lll
+		{"deployment", gitlab.EventTypeDeployment, "testdata/webhooks/deployment.json"}, //nolint:lll
 		{"emoji", gitlab.EventTypeEmoji, "testdata/webhooks/emoji.json"},
 		{"feature flag", gitlab.EventTypeFeatureFlag, "testdata/webhooks/feature_flag.json"},                                       //nolint:lll
 		{"group resource access token", gitlab.EventTypeResourceAccessToken, "testdata/webhooks/resource_access_token_group.json"}, //nolint:lll

--- a/dispatcher_test.go
+++ b/dispatcher_test.go
@@ -52,6 +52,7 @@ func TestDispatcher_Dispatch(t *testing.T) {
 		{"build", gitlab.EventTypeBuild, "testdata/webhooks/build.json"},                                                           //nolint:lll
 		{"commit comment", gitlab.EventTypeNote, "testdata/webhooks/note_commit.json"},                                             //nolint:lll
 		{"deployment", gitlab.EventTypeDeployment, "testdata/webhooks/deployment.json"},                                            //nolint:lll
+		{"emoji", gitlab.EventTypeEmoji, "testdata/webhooks/emoji.json"},
 		{"feature flag", gitlab.EventTypeFeatureFlag, "testdata/webhooks/feature_flag.json"},                                       //nolint:lll
 		{"group resource access token", gitlab.EventTypeResourceAccessToken, "testdata/webhooks/resource_access_token_group.json"}, //nolint:lll
 		{"issue comment", gitlab.EventTypeNote, "testdata/webhooks/note_issue.json"},                                               //nolint:lll
@@ -97,6 +98,7 @@ var (
 	_ BuildListener                      = (*testListener)(nil)
 	_ CommitCommentListener              = (*testListener)(nil)
 	_ DeploymentListener                 = (*testListener)(nil)
+	_ EmojiListener                      = (*testListener)(nil)
 	_ FeatureFlagListener                = (*testListener)(nil)
 	_ GroupResourceAccessTokenListener   = (*testListener)(nil)
 	_ IssueCommentListener               = (*testListener)(nil)
@@ -130,6 +132,13 @@ func (t *testListener) OnCommitComment(ctx context.Context, event *gitlab.Commit
 func (t *testListener) OnDeployment(ctx context.Context, event *gitlab.DeploymentEvent) error {
 	testDispatcherContext(ctx, t.t)
 	assert.Equal(t.t, "test-deployment-webhooks", event.Project.Name)
+	return nil
+}
+
+func (t *testListener) OnEmoji(ctx context.Context, event *gitlab.EmojiEvent) error {
+	testDispatcherContext(ctx, t.t)
+	assert.Equal(t.t, "awesome-project", event.Project.Name)
+	assert.Equal(t.t, "thumbsup", event.ObjectAttributes.Name)
 	return nil
 }
 

--- a/listeners.go
+++ b/listeners.go
@@ -18,6 +18,10 @@ type DeploymentListener interface {
 	OnDeployment(ctx context.Context, event *gitlab.DeploymentEvent) error
 }
 
+type EmojiListener interface {
+	OnEmoji(ctx context.Context, event *gitlab.EmojiEvent) error
+}
+
 type FeatureFlagListener interface {
 	OnFeatureFlag(ctx context.Context, event *gitlab.FeatureFlagEvent) error
 }

--- a/testdata/webhooks/emoji.json
+++ b/testdata/webhooks/emoji.json
@@ -1,0 +1,41 @@
+{
+  "object_kind": "emoji",
+  "event_type": "award",
+  "user": {
+    "id": 1,
+    "name": "Administrator",
+    "username": "root",
+    "avatar_url": "http://example.com/avatar.png",
+    "email": "root@example.com"
+  },
+  "project_id": 1,
+  "project": {
+    "id": 1,
+    "name": "awesome-project",
+    "description": "An example project",
+    "web_url": "http://example.com/projects/awesome-project",
+    "avatar_url": "",
+    "git_ssh_url": "git@example.com:awesome-project.git",
+    "git_http_url": "http://example.com/awesome-project.git",
+    "namespace": "example",
+    "visibility_level": 20,
+    "path_with_namespace": "example/awesome-project",
+    "default_branch": "main",
+    "ci_config_path": "",
+    "homepage": "http://example.com/projects/awesome-project",
+    "url": "git@example.com:awesome-project.git",
+    "ssh_url": "git@example.com:awesome-project.git",
+    "http_url": "http://example.com/awesome-project.git"
+  },
+  "object_attributes": {
+    "user_id": 1,
+    "created_at": "2025-01-01T00:00:00Z",
+    "id": 1,
+    "name": "thumbsup",
+    "awardable_type": "Issue",
+    "awardable_id": 2,
+    "updated_at": "2025-01-01T00:00:00Z",
+    "action": "award",
+    "awarded_on_url": "http://example.com/projects/awesome-project/issues/2"
+  }
+}


### PR DESCRIPTION
## Summary
- add dispatcher routing support for `*gitlab.EmojiEvent`
- add `EmojiListener` registration and processing
- add webhook fixture and tests for EmojiEvent dispatch

## Testing
- go test ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for emoji award events in the dispatcher.
  * Introduced an EmojiListener interface and a public way to register emoji listeners so apps can handle emoji events.

* **Tests**
  * Added comprehensive test coverage and a JSON fixture for emoji award webhook events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->