### PR TITLE
feat: add webhook middleware support

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ func main() {
 		gitlabwebhook.WithMiddlewares(
 			loggingMiddleware,
 			// Only runs for push events.
-			gitlabwebhook.ForEvent(func(ctx context.Context, event *gitlab.PushEvent) error {
+			gitlabwebhook.MiddlewareForEvent(func(ctx context.Context, event *gitlab.PushEvent) error {
 				log.Printf("push event: %s", event.Project.PathWithNamespace)
 				return nil
 			}),

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ package main
 
 import (
 	"context"
+	"log"
 	"net/http"
 
 	"github.com/flc1125/go-gitlab-webhook/v3"
@@ -86,6 +87,14 @@ func main() {
 			&testCommitCommentListener{},
 			&testBuildAndCommitCommentListener{},
 		),
+		gitlabwebhook.WithMiddlewares(
+			loggingMiddleware,
+			// Only runs for push events.
+			gitlabwebhook.ForEvent(func(ctx context.Context, event *gitlab.PushEvent) error {
+				log.Printf("push event: %s", event.Project.PathWithNamespace)
+				return nil
+			}),
+		),
 	)
 
 	dispatcher.RegisterListeners(
@@ -108,6 +117,13 @@ func main() {
 
 	if err := http.ListenAndServe(":8080", nil); err != nil {
 		panic(err)
+	}
+}
+
+func loggingMiddleware(next gitlabwebhook.HandlerFunc) gitlabwebhook.HandlerFunc {
+	return func(ctx context.Context, event any) error {
+		log.Printf("received webhook event: %T", event)
+		return next(ctx, event)
 	}
 }
 ```

--- a/dispatcher.go
+++ b/dispatcher.go
@@ -45,19 +45,9 @@ type Dispatcher struct {
 
 type Option func(*Dispatcher)
 
-type HandlerFunc func(ctx context.Context, event any) error
-
-type Middleware func(next HandlerFunc) HandlerFunc
-
 func RegisterListeners(listeners ...any) Option {
 	return func(d *Dispatcher) {
 		d.RegisterListeners(listeners...)
-	}
-}
-
-func WithMiddlewares(middlewares ...Middleware) Option {
-	return func(d *Dispatcher) {
-		d.Use(middlewares...)
 	}
 }
 
@@ -67,10 +57,6 @@ func NewDispatcher(opts ...Option) *Dispatcher {
 		opt(dispatcher)
 	}
 	return dispatcher
-}
-
-func (d *Dispatcher) Use(middlewares ...Middleware) {
-	d.middlewares = append(d.middlewares, middlewares...)
 }
 
 func (d *Dispatcher) RegisterListeners(listeners ...any) {

--- a/dispatcher.go
+++ b/dispatcher.go
@@ -40,13 +40,24 @@ type Dispatcher struct {
 	tagListeners                        []TagListener
 	vulnerabilityListeners              []VulnerabilityListener
 	wikiPageListeners                   []WikiPageListener
+	middlewares                         []Middleware
 }
 
 type Option func(*Dispatcher)
 
+type HandlerFunc func(ctx context.Context, event any) error
+
+type Middleware func(next HandlerFunc) HandlerFunc
+
 func RegisterListeners(listeners ...any) Option {
 	return func(d *Dispatcher) {
 		d.RegisterListeners(listeners...)
+	}
+}
+
+func WithMiddlewares(middlewares ...Middleware) Option {
+	return func(d *Dispatcher) {
+		d.Use(middlewares...)
 	}
 }
 
@@ -56,6 +67,10 @@ func NewDispatcher(opts ...Option) *Dispatcher {
 		opt(dispatcher)
 	}
 	return dispatcher
+}
+
+func (d *Dispatcher) Use(middlewares ...Middleware) {
+	d.middlewares = append(d.middlewares, middlewares...)
 }
 
 func (d *Dispatcher) RegisterListeners(listeners ...any) {
@@ -247,6 +262,16 @@ func (d *Dispatcher) RegisterWikiPageListener(listeners ...WikiPageListener) {
 }
 
 func (d *Dispatcher) Dispatch(ctx context.Context, event any) error {
+	handler := d.dispatchEvent
+
+	for i := len(d.middlewares) - 1; i >= 0; i-- {
+		handler = d.middlewares[i](handler)
+	}
+
+	return handler(ctx, event)
+}
+
+func (d *Dispatcher) dispatchEvent(ctx context.Context, event any) error {
 	switch e := event.(type) {
 	case *gitlab.BuildEvent:
 		return d.processBuildEvent(ctx, e)

--- a/dispatcher_test.go
+++ b/dispatcher_test.go
@@ -440,7 +440,7 @@ func TestDispatcher_Middleware(t *testing.T) {
 	t.Run("for event runs only for matching events", func(t *testing.T) {
 		called := false
 		dispatcher := NewDispatcher(
-			WithMiddlewares(ForEvent(func(ctx context.Context, event *gitlab.PushEvent) error {
+			WithMiddlewares(MiddlewareForEvent(func(ctx context.Context, event *gitlab.PushEvent) error {
 				called = true
 				return nil
 			})),
@@ -469,7 +469,7 @@ func TestDispatcher_Middleware(t *testing.T) {
 
 		dispatcher := NewDispatcher(
 			RegisterListeners(listener),
-			WithMiddlewares(ForEvent(func(ctx context.Context, event *gitlab.PushEvent) error {
+			WithMiddlewares(MiddlewareForEvent(func(ctx context.Context, event *gitlab.PushEvent) error {
 				return expectedErr
 			})),
 		)

--- a/dispatcher_test.go
+++ b/dispatcher_test.go
@@ -436,6 +436,48 @@ func TestDispatcher_Middleware(t *testing.T) {
 
 		assert.ErrorIs(t, err, expectedErr)
 	})
+
+	t.Run("for event runs only for matching events", func(t *testing.T) {
+		called := false
+		dispatcher := NewDispatcher(
+			WithMiddlewares(ForEvent(func(ctx context.Context, event *gitlab.PushEvent) error {
+				called = true
+				return nil
+			})),
+		)
+
+		err := dispatcher.Dispatch(t.Context(), &gitlab.PushEvent{})
+
+		assert.NoError(t, err)
+		assert.True(t, called)
+
+		called = false
+		err = dispatcher.Dispatch(t.Context(), &gitlab.MergeEvent{})
+
+		assert.NoError(t, err)
+		assert.False(t, called)
+	})
+
+	t.Run("for event can stop dispatch", func(t *testing.T) {
+		expectedErr := errors.New("stop push")
+		listener := &middlewareTestListener{
+			onPush: func(ctx context.Context, event *gitlab.PushEvent) error {
+				t.Fatal("listener should not be called")
+				return nil
+			},
+		}
+
+		dispatcher := NewDispatcher(
+			RegisterListeners(listener),
+			WithMiddlewares(ForEvent(func(ctx context.Context, event *gitlab.PushEvent) error {
+				return expectedErr
+			})),
+		)
+
+		err := dispatcher.Dispatch(t.Context(), &gitlab.PushEvent{})
+
+		assert.ErrorIs(t, err, expectedErr)
+	})
 }
 
 type middlewareTestListener struct {

--- a/dispatcher_test.go
+++ b/dispatcher_test.go
@@ -3,6 +3,7 @@ package gitlabwebhook
 import (
 	"bytes"
 	"context"
+	"errors"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -351,6 +352,100 @@ var _ PushListener = (*simpleTestListener)(nil)
 func (s *simpleTestListener) OnPush(ctx context.Context, event *gitlab.PushEvent) error {
 	s.called = true
 	return nil
+}
+
+type middlewareContextKey struct{}
+
+func TestDispatcher_Middleware(t *testing.T) {
+	t.Run("wraps listener dispatch", func(t *testing.T) {
+		order := make([]string, 0, 3)
+		listener := &middlewareTestListener{
+			onPush: func(ctx context.Context, event *gitlab.PushEvent) error {
+				order = append(order, "listener")
+				assert.Equal(t, "middleware", ctx.Value(middlewareContextKey{}))
+				return nil
+			},
+		}
+
+		dispatcher := NewDispatcher(
+			RegisterListeners(listener),
+			WithMiddlewares(func(next HandlerFunc) HandlerFunc {
+				return func(ctx context.Context, event any) error {
+					order = append(order, "middleware before")
+					ctx = context.WithValue(ctx, middlewareContextKey{}, "middleware")
+					err := next(ctx, event)
+					order = append(order, "middleware after")
+					return err
+				}
+			}),
+		)
+
+		err := dispatcher.Dispatch(t.Context(), &gitlab.PushEvent{})
+
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"middleware before", "listener", "middleware after"}, order)
+	})
+
+	t.Run("uses registration order", func(t *testing.T) {
+		order := make([]string, 0, 4)
+		dispatcher := NewDispatcher()
+		dispatcher.Use(
+			func(next HandlerFunc) HandlerFunc {
+				return func(ctx context.Context, event any) error {
+					order = append(order, "first before")
+					err := next(ctx, event)
+					order = append(order, "first after")
+					return err
+				}
+			},
+			func(next HandlerFunc) HandlerFunc {
+				return func(ctx context.Context, event any) error {
+					order = append(order, "second before")
+					err := next(ctx, event)
+					order = append(order, "second after")
+					return err
+				}
+			},
+		)
+
+		err := dispatcher.Dispatch(t.Context(), &gitlab.PushEvent{})
+
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"first before", "second before", "second after", "first after"}, order)
+	})
+
+	t.Run("can stop dispatch", func(t *testing.T) {
+		expectedErr := errors.New("stop dispatch")
+		listener := &middlewareTestListener{
+			onPush: func(ctx context.Context, event *gitlab.PushEvent) error {
+				t.Fatal("listener should not be called")
+				return nil
+			},
+		}
+
+		dispatcher := NewDispatcher(
+			RegisterListeners(listener),
+			WithMiddlewares(func(next HandlerFunc) HandlerFunc {
+				return func(ctx context.Context, event any) error {
+					return expectedErr
+				}
+			}),
+		)
+
+		err := dispatcher.Dispatch(t.Context(), &gitlab.PushEvent{})
+
+		assert.ErrorIs(t, err, expectedErr)
+	})
+}
+
+type middlewareTestListener struct {
+	onPush func(context.Context, *gitlab.PushEvent) error
+}
+
+var _ PushListener = (*middlewareTestListener)(nil)
+
+func (l *middlewareTestListener) OnPush(ctx context.Context, event *gitlab.PushEvent) error {
+	return l.onPush(ctx, event)
 }
 
 func loadFixture(filePath string) []byte {

--- a/middleware.go
+++ b/middleware.go
@@ -1,0 +1,32 @@
+package gitlabwebhook
+
+import "context"
+
+// HandlerFunc handles a parsed GitLab webhook event.
+//
+// The event argument is one of the concrete event pointer types returned by
+// gitlab.ParseWebhook, such as *gitlab.PushEvent or *gitlab.MergeEvent.
+type HandlerFunc func(ctx context.Context, event any) error
+
+// Middleware wraps a HandlerFunc to run code before or after event dispatch.
+//
+// A middleware can stop dispatch by returning an error without calling next.
+type Middleware func(next HandlerFunc) HandlerFunc
+
+// WithMiddlewares registers middleware during dispatcher construction.
+//
+// Middleware runs once per parsed webhook event, before the event is dispatched
+// to registered listeners.
+func WithMiddlewares(middlewares ...Middleware) Option {
+	return func(d *Dispatcher) {
+		d.Use(middlewares...)
+	}
+}
+
+// Use appends middleware to the dispatcher.
+//
+// Middleware is applied in registration order: the first middleware wraps the
+// second, and so on, with listener dispatch as the final handler.
+func (d *Dispatcher) Use(middlewares ...Middleware) {
+	d.middlewares = append(d.middlewares, middlewares...)
+}

--- a/middleware.go
+++ b/middleware.go
@@ -13,6 +13,27 @@ type HandlerFunc func(ctx context.Context, event any) error
 // A middleware can stop dispatch by returning an error without calling next.
 type Middleware func(next HandlerFunc) HandlerFunc
 
+// ForEvent returns middleware that runs fn only for events assignable to E.
+//
+// If fn returns an error, dispatch stops and that error is returned. Events of
+// other types skip fn and continue to the next handler.
+func ForEvent[E any](fn func(context.Context, E) error) Middleware {
+	return func(next HandlerFunc) HandlerFunc {
+		return func(ctx context.Context, event any) error {
+			e, ok := event.(E)
+			if !ok {
+				return next(ctx, event)
+			}
+
+			if err := fn(ctx, e); err != nil {
+				return err
+			}
+
+			return next(ctx, event)
+		}
+	}
+}
+
 // WithMiddlewares registers middleware during dispatcher construction.
 //
 // Middleware runs once per parsed webhook event, before the event is dispatched

--- a/middleware.go
+++ b/middleware.go
@@ -13,11 +13,11 @@ type HandlerFunc func(ctx context.Context, event any) error
 // A middleware can stop dispatch by returning an error without calling next.
 type Middleware func(next HandlerFunc) HandlerFunc
 
-// ForEvent returns middleware that runs fn only for events assignable to E.
+// MiddlewareForEvent returns middleware that runs fn only for events assignable to E.
 //
 // If fn returns an error, dispatch stops and that error is returned. Events of
 // other types skip fn and continue to the next handler.
-func ForEvent[E any](fn func(context.Context, E) error) Middleware {
+func MiddlewareForEvent[E any](fn func(context.Context, E) error) Middleware {
 	return func(next HandlerFunc) HandlerFunc {
 		return func(ctx context.Context, event any) error {
 			e, ok := event.(E)


### PR DESCRIPTION
## Summary
Add event-level middleware support to the GitLab webhook dispatcher so callers can run cross-cutting logic before listener dispatch.

## Changes
- Add `Middleware`, `HandlerFunc`, `WithMiddlewares`, and `Use` APIs
- Add `MiddlewareForEvent` for event-specific middleware behavior
- Route `Dispatch` through the middleware chain before existing listener dispatch
- Document middleware usage in the README

## Motivation
- Callers need a standard way to add logging, metrics, tracing, filtering, or authorization around parsed webhook events without changing listener implementations

## Testing
- `go test ./... -race`
- `make lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added middleware support to enable custom handling of webhook events, including logging, request/response modification, and event filtering
  * Supports global middleware and event-type-specific middleware

* **Documentation**
  * Updated usage examples demonstrating middleware implementation and practical logging use cases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->