### PR TITLE
feat(otel): add webhook metrics

### DIFF
--- a/middleware/otel/README.md
+++ b/middleware/otel/README.md
@@ -49,7 +49,7 @@ func main() {
 }
 ```
 
-## Tracer Provider
+## Provider
 
 By default, the middleware uses the global OpenTelemetry tracer and meter providers.
 Pass providers explicitly when your application wires telemetry without globals:
@@ -94,6 +94,7 @@ Event details are recorded as attributes, for example:
 The middleware records basic event handling metrics:
 
 - `gitlab.webhook.events`: count of handled webhook events
+- `gitlab.webhook.active_events`: number of webhook events currently being handled
 - `gitlab.webhook.event.duration`: event handling duration in seconds
 
 Metric attributes are intentionally low-cardinality:
@@ -104,3 +105,5 @@ Metric attributes are intentionally low-cardinality:
 - `gitlab.webhook.action`
 - `gitlab.webhook.status`
 - `gitlab.webhook.result`
+
+`gitlab.webhook.result` is only recorded on completed event metrics.

--- a/middleware/otel/README.md
+++ b/middleware/otel/README.md
@@ -1,6 +1,6 @@
 # GitLab Webhook OpenTelemetry Middleware
 
-OpenTelemetry tracing middleware for `github.com/flc1125/go-gitlab-webhook/v3`.
+OpenTelemetry tracing and metrics middleware for `github.com/flc1125/go-gitlab-webhook/v3`.
 
 ## Installation
 
@@ -51,14 +51,15 @@ func main() {
 
 ## Tracer Provider
 
-By default, the middleware uses the global OpenTelemetry tracer provider.
-Pass a provider explicitly when your application wires tracing without globals:
+By default, the middleware uses the global OpenTelemetry tracer and meter providers.
+Pass providers explicitly when your application wires telemetry without globals:
 
 ```go
 dispatcher := gitlabwebhook.NewDispatcher(
 	gitlabwebhook.WithMiddlewares(
 		otelmiddleware.Middleware(
 			otelmiddleware.WithTracerProvider(tracerProvider),
+			otelmiddleware.WithMeterProvider(meterProvider),
 		),
 	),
 )
@@ -87,3 +88,19 @@ Event details are recorded as attributes, for example:
 - `gitlab.project.path`
 - `gitlab.ref`
 - `gitlab.sha`
+
+## Metrics
+
+The middleware records basic event handling metrics:
+
+- `gitlab.webhook.events`: count of handled webhook events
+- `gitlab.webhook.event.duration`: event handling duration in seconds
+
+Metric attributes are intentionally low-cardinality:
+
+- `gitlab.webhook.event_type`
+- `gitlab.webhook.object_kind`
+- `gitlab.webhook.event_name`
+- `gitlab.webhook.action`
+- `gitlab.webhook.status`
+- `gitlab.webhook.result`

--- a/middleware/otel/config.go
+++ b/middleware/otel/config.go
@@ -2,11 +2,13 @@ package otel
 
 import (
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 )
 
 type config struct {
 	tracerProvider trace.TracerProvider
+	meterProvider  metric.MeterProvider
 }
 
 // Option configures the OpenTelemetry middleware.
@@ -29,9 +31,19 @@ func WithTracerProvider(provider trace.TracerProvider) Option {
 	})
 }
 
+// WithMeterProvider configures the meter provider used by the middleware.
+func WithMeterProvider(provider metric.MeterProvider) Option {
+	return optionFunc(func(c *config) {
+		if provider != nil {
+			c.meterProvider = provider
+		}
+	})
+}
+
 func newConfig(opts ...Option) *config {
 	cfg := &config{
 		tracerProvider: otel.GetTracerProvider(),
+		meterProvider:  otel.GetMeterProvider(),
 	}
 
 	for _, opt := range opts {

--- a/middleware/otel/go.mod
+++ b/middleware/otel/go.mod
@@ -7,7 +7,9 @@ require (
 	github.com/stretchr/testify v1.11.1
 	gitlab.com/gitlab-org/api/client-go/v2 v2.21.0
 	go.opentelemetry.io/otel v1.43.0
+	go.opentelemetry.io/otel/metric v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0
+	go.opentelemetry.io/otel/sdk/metric v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
 )
 
@@ -22,7 +24,6 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.7.8 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
-	go.opentelemetry.io/otel/metric v1.43.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/time v0.15.0 // indirect

--- a/middleware/otel/internal/metrics/metrics.go
+++ b/middleware/otel/internal/metrics/metrics.go
@@ -19,6 +19,7 @@ const (
 // Metrics records GitLab webhook event metrics.
 type Metrics struct {
 	events   metric.Int64Counter
+	active   metric.Int64UpDownCounter
 	duration metric.Float64Histogram
 }
 
@@ -38,6 +39,15 @@ func New(provider metric.MeterProvider, instrumentationName, instrumentationVers
 		events = noop.Int64Counter{}
 	}
 
+	active, err := meter.Int64UpDownCounter(
+		"gitlab.webhook.active_events",
+		metric.WithDescription("Number of GitLab webhook events currently being handled."),
+		metric.WithUnit("{event}"),
+	)
+	if err != nil {
+		active = noop.Int64UpDownCounter{}
+	}
+
 	duration, err := meter.Float64Histogram(
 		"gitlab.webhook.event.duration",
 		metric.WithDescription("Duration of GitLab webhook event handling."),
@@ -49,8 +59,14 @@ func New(provider metric.MeterProvider, instrumentationName, instrumentationVers
 
 	return Metrics{
 		events:   events,
+		active:   active,
 		duration: duration,
 	}
+}
+
+// RecordActive records the current number of webhook events being handled.
+func (m Metrics) RecordActive(ctx context.Context, metadata eventmeta.Metadata, delta int64) {
+	m.active.Add(ctx, delta, metric.WithAttributes(metricAttributes(metadata.Attributes)...))
 }
 
 // Record records the handling result and duration for a webhook event.

--- a/middleware/otel/internal/metrics/metrics.go
+++ b/middleware/otel/internal/metrics/metrics.go
@@ -1,0 +1,84 @@
+package metrics
+
+import (
+	"context"
+	"time"
+
+	"github.com/flc1125/go-gitlab-webhook/middleware/otel/v3/internal/eventmeta"
+	"github.com/flc1125/go-gitlab-webhook/middleware/otel/v3/internal/semconv"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
+)
+
+const (
+	webhookResultSuccess = "success"
+	webhookResultError   = "error"
+)
+
+// Metrics records GitLab webhook event metrics.
+type Metrics struct {
+	events   metric.Int64Counter
+	duration metric.Float64Histogram
+}
+
+// New creates the OpenTelemetry instruments used by the middleware.
+func New(provider metric.MeterProvider, instrumentationName, instrumentationVersion string) Metrics {
+	meter := provider.Meter(
+		instrumentationName,
+		metric.WithInstrumentationVersion(instrumentationVersion),
+	)
+
+	events, err := meter.Int64Counter(
+		"gitlab.webhook.events",
+		metric.WithDescription("Total number of GitLab webhook events handled."),
+		metric.WithUnit("{event}"),
+	)
+	if err != nil {
+		events = noop.Int64Counter{}
+	}
+
+	duration, err := meter.Float64Histogram(
+		"gitlab.webhook.event.duration",
+		metric.WithDescription("Duration of GitLab webhook event handling."),
+		metric.WithUnit("s"),
+	)
+	if err != nil {
+		duration = noop.Float64Histogram{}
+	}
+
+	return Metrics{
+		events:   events,
+		duration: duration,
+	}
+}
+
+// Record records the handling result and duration for a webhook event.
+func (m Metrics) Record(ctx context.Context, metadata eventmeta.Metadata, elapsed time.Duration, err error) {
+	result := webhookResultSuccess
+	if err != nil {
+		result = webhookResultError
+	}
+
+	attrs := append(metricAttributes(metadata.Attributes), semconv.WebhookResult(result))
+	opts := metric.WithAttributes(attrs...)
+
+	m.events.Add(ctx, 1, opts)
+	m.duration.Record(ctx, elapsed.Seconds(), opts)
+}
+
+func metricAttributes(attrs []attribute.KeyValue) []attribute.KeyValue {
+	values := make([]attribute.KeyValue, 0, len(attrs))
+	for _, attr := range attrs {
+		switch attr.Key {
+		case semconv.WebhookEventTypeKey,
+			semconv.WebhookObjectKindKey,
+			semconv.WebhookEventNameKey,
+			semconv.WebhookActionKey,
+			semconv.WebhookStatusKey:
+			values = append(values, attr)
+		}
+	}
+
+	return values
+}

--- a/middleware/otel/internal/metrics/metrics_test.go
+++ b/middleware/otel/internal/metrics/metrics_test.go
@@ -1,0 +1,90 @@
+package metrics_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/flc1125/go-gitlab-webhook/middleware/otel/v3/internal/eventmeta"
+	"github.com/flc1125/go-gitlab-webhook/middleware/otel/v3/internal/metrics"
+	"github.com/flc1125/go-gitlab-webhook/middleware/otel/v3/internal/semconv"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+func TestRecord(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	recorder := metrics.New(provider, "test/instrumentation", "v0.0.0")
+	metadata := eventmeta.Metadata{
+		SpanName: "gitlab.webhook.push",
+		Attributes: []attribute.KeyValue{
+			semconv.WebhookEventType("push"),
+			semconv.WebhookObjectKind("push"),
+			semconv.ProjectPath("group/project"),
+			semconv.Ref("refs/heads/main"),
+		},
+	}
+
+	recorder.Record(context.Background(), metadata, time.Second, nil)
+
+	rm := collectMetrics(t, reader)
+	events := metricByName(t, rm, "gitlab.webhook.events")
+	eventSum, ok := events.Data.(metricdata.Sum[int64])
+	require.True(t, ok)
+	require.Len(t, eventSum.DataPoints, 1)
+	assert.Equal(t, int64(1), eventSum.DataPoints[0].Value)
+	assertAttrString(t, eventSum.DataPoints[0].Attributes, "gitlab.webhook.event_type", "push")
+	assertAttrString(t, eventSum.DataPoints[0].Attributes, "gitlab.webhook.object_kind", "push")
+	assertAttrString(t, eventSum.DataPoints[0].Attributes, "gitlab.webhook.result", "success")
+	assertNoAttr(t, eventSum.DataPoints[0].Attributes, "gitlab.project.path")
+	assertNoAttr(t, eventSum.DataPoints[0].Attributes, "gitlab.ref")
+
+	duration := metricByName(t, rm, "gitlab.webhook.event.duration")
+	histogram, ok := duration.Data.(metricdata.Histogram[float64])
+	require.True(t, ok)
+	require.Len(t, histogram.DataPoints, 1)
+	assert.Equal(t, uint64(1), histogram.DataPoints[0].Count)
+}
+
+func collectMetrics(t *testing.T, reader *sdkmetric.ManualReader) metricdata.ResourceMetrics {
+	t.Helper()
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &rm))
+
+	return rm
+}
+
+func metricByName(t *testing.T, rm metricdata.ResourceMetrics, name string) metricdata.Metrics {
+	t.Helper()
+
+	for _, scope := range rm.ScopeMetrics {
+		for _, metric := range scope.Metrics {
+			if metric.Name == name {
+				return metric
+			}
+		}
+	}
+
+	require.Failf(t, "metric not found", "metric %q was not collected", name)
+	return metricdata.Metrics{}
+}
+
+func assertAttrString(t *testing.T, attrs attribute.Set, key, expected string) {
+	t.Helper()
+
+	value, ok := attrs.Value(attribute.Key(key))
+	require.Truef(t, ok, "attribute %q was not found", key)
+	assert.Equal(t, expected, value.AsString())
+}
+
+func assertNoAttr(t *testing.T, attrs attribute.Set, key string) {
+	t.Helper()
+
+	_, ok := attrs.Value(attribute.Key(key))
+	assert.Falsef(t, ok, "attribute %q should not be recorded", key)
+}

--- a/middleware/otel/internal/metrics/metrics_test.go
+++ b/middleware/otel/internal/metrics/metrics_test.go
@@ -29,7 +29,9 @@ func TestRecord(t *testing.T) {
 		},
 	}
 
+	recorder.RecordActive(context.Background(), metadata, 1)
 	recorder.Record(context.Background(), metadata, time.Second, nil)
+	recorder.RecordActive(context.Background(), metadata, -1)
 
 	rm := collectMetrics(t, reader)
 	events := metricByName(t, rm, "gitlab.webhook.events")
@@ -48,6 +50,14 @@ func TestRecord(t *testing.T) {
 	require.True(t, ok)
 	require.Len(t, histogram.DataPoints, 1)
 	assert.Equal(t, uint64(1), histogram.DataPoints[0].Count)
+
+	active := metricByName(t, rm, "gitlab.webhook.active_events")
+	activeSum, ok := active.Data.(metricdata.Sum[int64])
+	require.True(t, ok)
+	require.Len(t, activeSum.DataPoints, 1)
+	assert.Equal(t, int64(0), activeSum.DataPoints[0].Value)
+	assertAttrString(t, activeSum.DataPoints[0].Attributes, "gitlab.webhook.event_type", "push")
+	assertNoAttr(t, activeSum.DataPoints[0].Attributes, "gitlab.webhook.result")
 }
 
 func collectMetrics(t *testing.T, reader *sdkmetric.ManualReader) metricdata.ResourceMetrics {

--- a/middleware/otel/internal/semconv/attribute.go
+++ b/middleware/otel/internal/semconv/attribute.go
@@ -8,6 +8,7 @@ const (
 	WebhookEventNameKey  = attribute.Key("gitlab.webhook.event_name")
 	WebhookActionKey     = attribute.Key("gitlab.webhook.action")
 	WebhookStatusKey     = attribute.Key("gitlab.webhook.status")
+	WebhookResultKey     = attribute.Key("gitlab.webhook.result")
 	WebhookGoTypeKey     = attribute.Key("gitlab.webhook.go_type")
 
 	ProjectIDKey          = attribute.Key("gitlab.project.id")
@@ -82,6 +83,10 @@ func WebhookAction(val string) attribute.KeyValue {
 
 func WebhookStatus(val string) attribute.KeyValue {
 	return WebhookStatusKey.String(val)
+}
+
+func WebhookResult(val string) attribute.KeyValue {
+	return WebhookResultKey.String(val)
 }
 
 func WebhookGoType(val string) attribute.KeyValue {

--- a/middleware/otel/middleware.go
+++ b/middleware/otel/middleware.go
@@ -2,8 +2,10 @@ package otel
 
 import (
 	"context"
+	"time"
 
 	"github.com/flc1125/go-gitlab-webhook/middleware/otel/v3/internal/eventmeta"
+	"github.com/flc1125/go-gitlab-webhook/middleware/otel/v3/internal/metrics"
 	gitlabwebhook "github.com/flc1125/go-gitlab-webhook/v3"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
@@ -20,10 +22,12 @@ func Middleware(opts ...Option) gitlabwebhook.Middleware {
 		instrumentationName,
 		trace.WithInstrumentationVersion(Version()),
 	)
+	metricRecorder := metrics.New(cfg.meterProvider, instrumentationName, Version())
 
 	return func(next gitlabwebhook.HandlerFunc) gitlabwebhook.HandlerFunc {
 		return func(ctx context.Context, event any) error {
 			metadata := eventmeta.Extract(event)
+			start := time.Now()
 			ctx, span := tracer.Start(ctx,
 				metadata.SpanName,
 				trace.WithAttributes(metadata.Attributes...),
@@ -35,6 +39,8 @@ func Middleware(opts ...Option) gitlabwebhook.Middleware {
 				span.RecordError(err)
 				span.SetStatus(codes.Error, err.Error())
 			}
+
+			metricRecorder.Record(ctx, metadata, time.Since(start), err)
 
 			return err
 		}

--- a/middleware/otel/middleware.go
+++ b/middleware/otel/middleware.go
@@ -26,8 +26,11 @@ func Middleware(opts ...Option) gitlabwebhook.Middleware {
 
 	return func(next gitlabwebhook.HandlerFunc) gitlabwebhook.HandlerFunc {
 		return func(ctx context.Context, event any) error {
-			metadata := eventmeta.Extract(event)
 			start := time.Now()
+			metadata := eventmeta.Extract(event)
+			metricRecorder.RecordActive(ctx, metadata, 1)
+			defer metricRecorder.RecordActive(ctx, metadata, -1)
+
 			ctx, span := tracer.Start(ctx,
 				metadata.SpanName,
 				trace.WithAttributes(metadata.Attributes...),

--- a/middleware/otel/middleware_test.go
+++ b/middleware/otel/middleware_test.go
@@ -11,6 +11,8 @@ import (
 	gitlab "gitlab.com/gitlab-org/api/client-go/v2"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"go.opentelemetry.io/otel/trace"
@@ -88,6 +90,45 @@ func TestMiddlewareSkipsNilOption(t *testing.T) {
 	assert.Len(t, recorder.Ended(), 1)
 }
 
+func TestMiddlewareRecordsMetrics(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	event := &gitlab.PushEvent{
+		ObjectKind: "push",
+		EventName:  "push",
+		ProjectID:  123,
+		Ref:        "refs/heads/main",
+		Project: gitlab.PushEventProject{
+			PathWithNamespace: "group/project",
+		},
+	}
+
+	handler := otel.Middleware(otel.WithMeterProvider(provider))(func(context.Context, any) error {
+		return nil
+	})
+
+	err := handler(context.Background(), event)
+	require.NoError(t, err)
+
+	rm := collectMetrics(t, reader)
+	events := metricByName(t, rm, "gitlab.webhook.events")
+	eventSum, ok := events.Data.(metricdata.Sum[int64])
+	require.True(t, ok)
+	require.Len(t, eventSum.DataPoints, 1)
+	assert.Equal(t, int64(1), eventSum.DataPoints[0].Value)
+	assertAttrString(t, eventSum.DataPoints[0].Attributes, "gitlab.webhook.event_type", "push")
+	assertAttrString(t, eventSum.DataPoints[0].Attributes, "gitlab.webhook.object_kind", "push")
+	assertAttrString(t, eventSum.DataPoints[0].Attributes, "gitlab.webhook.result", "success")
+	assertNoAttr(t, eventSum.DataPoints[0].Attributes, "gitlab.project.path")
+	assertNoAttr(t, eventSum.DataPoints[0].Attributes, "gitlab.ref")
+
+	duration := metricByName(t, rm, "gitlab.webhook.event.duration")
+	histogram, ok := duration.Data.(metricdata.Histogram[float64])
+	require.True(t, ok)
+	require.Len(t, histogram.DataPoints, 1)
+	assert.Equal(t, uint64(1), histogram.DataPoints[0].Count)
+}
+
 func attrString(attrs []attribute.KeyValue, key string) string {
 	for _, attr := range attrs {
 		if string(attr.Key) == key {
@@ -106,4 +147,43 @@ func attrInt64(attrs []attribute.KeyValue, key string) int64 {
 	}
 
 	return 0
+}
+
+func collectMetrics(t *testing.T, reader *sdkmetric.ManualReader) metricdata.ResourceMetrics {
+	t.Helper()
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &rm))
+
+	return rm
+}
+
+func metricByName(t *testing.T, rm metricdata.ResourceMetrics, name string) metricdata.Metrics {
+	t.Helper()
+
+	for _, scope := range rm.ScopeMetrics {
+		for _, metric := range scope.Metrics {
+			if metric.Name == name {
+				return metric
+			}
+		}
+	}
+
+	require.Failf(t, "metric not found", "metric %q was not collected", name)
+	return metricdata.Metrics{}
+}
+
+func assertAttrString(t *testing.T, attrs attribute.Set, key, expected string) {
+	t.Helper()
+
+	value, ok := attrs.Value(attribute.Key(key))
+	require.Truef(t, ok, "attribute %q was not found", key)
+	assert.Equal(t, expected, value.AsString())
+}
+
+func assertNoAttr(t *testing.T, attrs attribute.Set, key string) {
+	t.Helper()
+
+	_, ok := attrs.Value(attribute.Key(key))
+	assert.Falsef(t, ok, "attribute %q should not be recorded", key)
 }

--- a/middleware/otel/middleware_test.go
+++ b/middleware/otel/middleware_test.go
@@ -11,8 +11,6 @@ import (
 	gitlab "gitlab.com/gitlab-org/api/client-go/v2"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
-	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
-	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"go.opentelemetry.io/otel/trace"
@@ -90,45 +88,6 @@ func TestMiddlewareSkipsNilOption(t *testing.T) {
 	assert.Len(t, recorder.Ended(), 1)
 }
 
-func TestMiddlewareRecordsMetrics(t *testing.T) {
-	reader := sdkmetric.NewManualReader()
-	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
-	event := &gitlab.PushEvent{
-		ObjectKind: "push",
-		EventName:  "push",
-		ProjectID:  123,
-		Ref:        "refs/heads/main",
-		Project: gitlab.PushEventProject{
-			PathWithNamespace: "group/project",
-		},
-	}
-
-	handler := otel.Middleware(otel.WithMeterProvider(provider))(func(context.Context, any) error {
-		return nil
-	})
-
-	err := handler(context.Background(), event)
-	require.NoError(t, err)
-
-	rm := collectMetrics(t, reader)
-	events := metricByName(t, rm, "gitlab.webhook.events")
-	eventSum, ok := events.Data.(metricdata.Sum[int64])
-	require.True(t, ok)
-	require.Len(t, eventSum.DataPoints, 1)
-	assert.Equal(t, int64(1), eventSum.DataPoints[0].Value)
-	assertAttrString(t, eventSum.DataPoints[0].Attributes, "gitlab.webhook.event_type", "push")
-	assertAttrString(t, eventSum.DataPoints[0].Attributes, "gitlab.webhook.object_kind", "push")
-	assertAttrString(t, eventSum.DataPoints[0].Attributes, "gitlab.webhook.result", "success")
-	assertNoAttr(t, eventSum.DataPoints[0].Attributes, "gitlab.project.path")
-	assertNoAttr(t, eventSum.DataPoints[0].Attributes, "gitlab.ref")
-
-	duration := metricByName(t, rm, "gitlab.webhook.event.duration")
-	histogram, ok := duration.Data.(metricdata.Histogram[float64])
-	require.True(t, ok)
-	require.Len(t, histogram.DataPoints, 1)
-	assert.Equal(t, uint64(1), histogram.DataPoints[0].Count)
-}
-
 func attrString(attrs []attribute.KeyValue, key string) string {
 	for _, attr := range attrs {
 		if string(attr.Key) == key {
@@ -147,43 +106,4 @@ func attrInt64(attrs []attribute.KeyValue, key string) int64 {
 	}
 
 	return 0
-}
-
-func collectMetrics(t *testing.T, reader *sdkmetric.ManualReader) metricdata.ResourceMetrics {
-	t.Helper()
-
-	var rm metricdata.ResourceMetrics
-	require.NoError(t, reader.Collect(t.Context(), &rm))
-
-	return rm
-}
-
-func metricByName(t *testing.T, rm metricdata.ResourceMetrics, name string) metricdata.Metrics {
-	t.Helper()
-
-	for _, scope := range rm.ScopeMetrics {
-		for _, metric := range scope.Metrics {
-			if metric.Name == name {
-				return metric
-			}
-		}
-	}
-
-	require.Failf(t, "metric not found", "metric %q was not collected", name)
-	return metricdata.Metrics{}
-}
-
-func assertAttrString(t *testing.T, attrs attribute.Set, key, expected string) {
-	t.Helper()
-
-	value, ok := attrs.Value(attribute.Key(key))
-	require.Truef(t, ok, "attribute %q was not found", key)
-	assert.Equal(t, expected, value.AsString())
-}
-
-func assertNoAttr(t *testing.T, attrs attribute.Set, key string) {
-	t.Helper()
-
-	_, ok := attrs.Value(attribute.Key(key))
-	assert.Falsef(t, ok, "attribute %q should not be recorded", key)
 }


### PR DESCRIPTION
## Summary
Add OpenTelemetry metrics to the GitLab webhook middleware alongside the existing tracing behavior.

## Changes
- Add meter provider configuration with `WithMeterProvider`
- Record handled event count, active event count, and event handling duration metrics
- Keep metric attributes low-cardinality and document the emitted metrics
- Move focused metric coverage into the internal metrics package

## Motivation
- Let users observe webhook throughput, in-flight work, and handling latency without changing listener code

## Testing
- go test -count=1 ./... in middleware/otel
- make lint