### PR TITLE
ci: upload canonical codecov report

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,9 @@ jobs:
         run: make test-coverage
 
       - name: Upload coverage to Codecov
+        if: matrix.go-version == '1.26.x' && matrix.platform == 'ubuntu-latest'
         uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage.txt
+          disable_search: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,11 @@
-coverage:
+codecov:
   require_ci_to_pass: true
 
+fixes:
+  - "github.com/flc1125/go-gitlab-webhook/v3/::"
+  - "github.com/flc1125/go-gitlab-webhook/middleware/otel/v3/::middleware/otel/"
+
+coverage:
   status:
     project:
       default:


### PR DESCRIPTION
## Summary
Normalize Codecov uploads so the repository reports coverage from the merged Go coverage profile instead of mixing module-level reports with the merged report.

## Changes
- Upload only `coverage.txt` from the Go 1.26 Ubuntu test job
- Disable Codecov's automatic coverage file search to avoid duplicate report uploads
- Add path fixes for the root module and `middleware/otel` module import paths

## Motivation
- The previous Codecov upload could include `coverage.out`, `coverage.txt`, and `middleware/otel/coverage.out`, which made the reported coverage inconsistent with the combined multi-module profile

## Testing
- `git diff --check`
- `make -n test-coverage`
- `curl -X POST --data-binary @codecov.yml https://codecov.io/validate`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline configuration for improved code coverage reporting and reliability. Updated test workflow to conditionally run coverage uploads with optimized settings. Refined code coverage thresholds and added path-based configuration patterns for better coverage tracking accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->