### PR TITLE
test: improve coverage follow-up

### DIFF
--- a/dispatcher_test.go
+++ b/dispatcher_test.go
@@ -55,10 +55,11 @@ func TestDispatcher_Dispatch(t *testing.T) {
 		{"commit comment", gitlab.EventTypeNote, "webhooks/note_commit.json"},  //nolint:lll
 		{"deployment", gitlab.EventTypeDeployment, "webhooks/deployment.json"}, //nolint:lll
 		{"emoji", gitlab.EventTypeEmoji, "webhooks/emoji.json"},
-		{"feature flag", gitlab.EventTypeFeatureFlag, "webhooks/feature_flag.json"},                                       //nolint:lll
-		{"group resource access token", gitlab.EventTypeResourceAccessToken, "webhooks/resource_access_token_group.json"}, //nolint:lll
-		{"issue comment", gitlab.EventTypeNote, "webhooks/note_issue.json"},                                               //nolint:lll
-		{"issue", gitlab.EventTypeIssue, "webhooks/issue.json"},                                                           //nolint:lll
+		{"feature flag", gitlab.EventTypeFeatureFlag, "webhooks/feature_flag.json"},                                           //nolint:lll
+		{"group resource access token", gitlab.EventTypeResourceAccessToken, "webhooks/resource_access_token_group.json"},     //nolint:lll
+		{"project resource access token", gitlab.EventTypeResourceAccessToken, "webhooks/resource_access_token_project.json"}, //nolint:lll
+		{"issue comment", gitlab.EventTypeNote, "webhooks/note_issue.json"},                                                   //nolint:lll
+		{"issue", gitlab.EventTypeIssue, "webhooks/issue.json"},                                                               //nolint:lll
 		{"job", gitlab.EventTypeJob, "webhooks/job.json"},
 		{"member", gitlab.EventTypeMember, "webhooks/member.json"},
 		{"milestone", gitlab.EventTypeMilestone, "webhooks/milestone.json"},

--- a/middleware/otel/internal/metrics/metrics_test.go
+++ b/middleware/otel/internal/metrics/metrics_test.go
@@ -2,6 +2,7 @@ package metrics_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -58,6 +59,39 @@ func TestRecord(t *testing.T) {
 	assert.Equal(t, int64(0), activeSum.DataPoints[0].Value)
 	assertAttrString(t, activeSum.DataPoints[0].Attributes, "gitlab.webhook.event_type", "push")
 	assertNoAttr(t, activeSum.DataPoints[0].Attributes, "gitlab.webhook.result")
+}
+
+func TestRecordError(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	recorder := metrics.New(provider, "test/instrumentation", "v0.0.0")
+	metadata := eventmeta.Metadata{
+		SpanName: "gitlab.webhook.merge_request close",
+		Attributes: []attribute.KeyValue{
+			semconv.WebhookEventType("merge_request"),
+			semconv.WebhookAction("close"),
+			semconv.ProjectPath("group/project"),
+		},
+	}
+
+	recorder.Record(context.Background(), metadata, 250*time.Millisecond, errors.New("listener failed"))
+
+	rm := collectMetrics(t, reader)
+	events := metricByName(t, rm, "gitlab.webhook.events")
+	eventSum, ok := events.Data.(metricdata.Sum[int64])
+	require.True(t, ok)
+	require.Len(t, eventSum.DataPoints, 1)
+	assert.Equal(t, int64(1), eventSum.DataPoints[0].Value)
+	assertAttrString(t, eventSum.DataPoints[0].Attributes, "gitlab.webhook.event_type", "merge_request")
+	assertAttrString(t, eventSum.DataPoints[0].Attributes, "gitlab.webhook.action", "close")
+	assertAttrString(t, eventSum.DataPoints[0].Attributes, "gitlab.webhook.result", "error")
+	assertNoAttr(t, eventSum.DataPoints[0].Attributes, "gitlab.project.path")
+
+	duration := metricByName(t, rm, "gitlab.webhook.event.duration")
+	histogram, ok := duration.Data.(metricdata.Histogram[float64])
+	require.True(t, ok)
+	require.Len(t, histogram.DataPoints, 1)
+	assert.Equal(t, uint64(1), histogram.DataPoints[0].Count)
 }
 
 func collectMetrics(t *testing.T, reader *sdkmetric.ManualReader) metricdata.ResourceMetrics {

--- a/middleware/otel/middleware_test.go
+++ b/middleware/otel/middleware_test.go
@@ -11,6 +11,8 @@ import (
 	gitlab "gitlab.com/gitlab-org/api/client-go/v2"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"go.opentelemetry.io/otel/trace"
@@ -88,6 +90,30 @@ func TestMiddlewareSkipsNilOption(t *testing.T) {
 	assert.Len(t, recorder.Ended(), 1)
 }
 
+func TestMiddlewareRecordsMetricsWithMeterProvider(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	handler := otel.Middleware(otel.WithMeterProvider(provider))(func(context.Context, any) error {
+		return nil
+	})
+
+	err := handler(context.Background(), &gitlab.PushEvent{
+		ObjectKind: "push",
+		EventName:  "push",
+	})
+	require.NoError(t, err)
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &rm))
+	events := metricByName(t, rm, "gitlab.webhook.events")
+	eventSum, ok := events.Data.(metricdata.Sum[int64])
+	require.True(t, ok)
+	require.Len(t, eventSum.DataPoints, 1)
+	assert.Equal(t, int64(1), eventSum.DataPoints[0].Value)
+	assertMetricAttrString(t, eventSum.DataPoints[0].Attributes, "gitlab.webhook.event_type", "push")
+	assertMetricAttrString(t, eventSum.DataPoints[0].Attributes, "gitlab.webhook.result", "success")
+}
+
 func attrString(attrs []attribute.KeyValue, key string) string {
 	for _, attr := range attrs {
 		if string(attr.Key) == key {
@@ -106,4 +132,27 @@ func attrInt64(attrs []attribute.KeyValue, key string) int64 {
 	}
 
 	return 0
+}
+
+func metricByName(t *testing.T, rm metricdata.ResourceMetrics, name string) metricdata.Metrics {
+	t.Helper()
+
+	for _, scope := range rm.ScopeMetrics {
+		for _, metric := range scope.Metrics {
+			if metric.Name == name {
+				return metric
+			}
+		}
+	}
+
+	require.Failf(t, "metric not found", "metric %q was not collected", name)
+	return metricdata.Metrics{}
+}
+
+func assertMetricAttrString(t *testing.T, attrs attribute.Set, key, expected string) {
+	t.Helper()
+
+	value, ok := attrs.Value(attribute.Key(key))
+	require.Truef(t, ok, "attribute %q was not found", key)
+	assert.Equal(t, expected, value.AsString())
 }


### PR DESCRIPTION
## Summary
Add a small follow-up set of tests to cover remaining practical webhook and otel paths.

## Changes
- Cover project resource access token dispatch using the existing fixture
- Verify otel middleware records metrics through a configured meter provider
- Cover error-result metric recording without forcing low-value instrument creation failures

## Motivation
- Raise coverage for real paths while avoiding brittle tests for hard-to-trigger internals

## Testing
- go test ./...
- go test ./... in middleware/otel
- go test -coverpkg=./... -covermode=atomic ./... -coverprofile=/private/tmp/go-gitlab-webhook-root-follow-up.cover
- go test -coverpkg=./... -covermode=atomic ./... -coverprofile=/private/tmp/go-gitlab-webhook-otel-follow-up.cover