### PR TITLE
docs: complete exported API comments

### DIFF
--- a/dispatcher.go
+++ b/dispatcher.go
@@ -53,6 +53,7 @@ type Dispatcher struct {
 	middlewares                         []Middleware
 }
 
+// Option configures a Dispatcher during construction.
 type Option func(*Dispatcher)
 
 // RegisterListeners registers listeners during dispatcher construction.
@@ -180,98 +181,128 @@ func (d *Dispatcher) RegisterListeners(listeners ...any) {
 	}
 }
 
+// RegisterBuildListener registers listeners for build events.
 func (d *Dispatcher) RegisterBuildListener(listeners ...BuildListener) {
 	d.buildListeners = append(d.buildListeners, listeners...)
 }
 
+// RegisterCommitCommentListener registers listeners for commit comment events.
 func (d *Dispatcher) RegisterCommitCommentListener(listeners ...CommitCommentListener) {
 	d.commitCommentListeners = append(d.commitCommentListeners, listeners...)
 }
 
+// RegisterDeploymentListener registers listeners for deployment events.
 func (d *Dispatcher) RegisterDeploymentListener(listeners ...DeploymentListener) {
 	d.deploymentListeners = append(d.deploymentListeners, listeners...)
 }
 
+// RegisterEmojiListener registers listeners for emoji events.
 func (d *Dispatcher) RegisterEmojiListener(listeners ...EmojiListener) {
 	d.emojiListeners = append(d.emojiListeners, listeners...)
 }
 
+// RegisterFeatureFlagListener registers listeners for feature flag events.
 func (d *Dispatcher) RegisterFeatureFlagListener(listeners ...FeatureFlagListener) {
 	d.featureFlagListeners = append(d.featureFlagListeners, listeners...)
 }
 
+// RegisterGroupResourceAccessTokenListener registers listeners for group
+// resource access token events.
 func (d *Dispatcher) RegisterGroupResourceAccessTokenListener(listeners ...GroupResourceAccessTokenListener) {
 	d.groupResourceAccessTokenListeners = append(d.groupResourceAccessTokenListeners, listeners...)
 }
 
+// RegisterIssueCommentListener registers listeners for issue comment events.
 func (d *Dispatcher) RegisterIssueCommentListener(listeners ...IssueCommentListener) {
 	d.issueCommentListeners = append(d.issueCommentListeners, listeners...)
 }
 
+// RegisterIssueListener registers listeners for issue events.
 func (d *Dispatcher) RegisterIssueListener(listeners ...IssueListener) {
 	d.issueListeners = append(d.issueListeners, listeners...)
 }
 
+// RegisterJobListener registers listeners for job events.
 func (d *Dispatcher) RegisterJobListener(listeners ...JobListener) {
 	d.jobListeners = append(d.jobListeners, listeners...)
 }
 
+// RegisterMemberListener registers listeners for member events.
 func (d *Dispatcher) RegisterMemberListener(listeners ...MemberListener) {
 	d.memberListeners = append(d.memberListeners, listeners...)
 }
 
+// RegisterMilestoneListener registers listeners for milestone events.
 func (d *Dispatcher) RegisterMilestoneListener(listeners ...MilestoneListener) {
 	d.milestoneListeners = append(d.milestoneListeners, listeners...)
 }
 
+// RegisterMergeCommentListener registers listeners for merge request comment events.
 func (d *Dispatcher) RegisterMergeCommentListener(listeners ...MergeCommentListener) {
 	d.mergeCommentListeners = append(d.mergeCommentListeners, listeners...)
 }
 
+// RegisterMergeListener registers listeners for merge request events.
 func (d *Dispatcher) RegisterMergeListener(listeners ...MergeListener) {
 	d.mergeListeners = append(d.mergeListeners, listeners...)
 }
 
+// RegisterPipelineListener registers listeners for pipeline events.
 func (d *Dispatcher) RegisterPipelineListener(listeners ...PipelineListener) {
 	d.pipelineListeners = append(d.pipelineListeners, listeners...)
 }
 
+// RegisterProjectListener registers listeners for project events.
 func (d *Dispatcher) RegisterProjectListener(listeners ...ProjectListener) {
 	d.projectListeners = append(d.projectListeners, listeners...)
 }
 
+// RegisterProjectResourceAccessTokenListener registers listeners for project
+// resource access token events.
 func (d *Dispatcher) RegisterProjectResourceAccessTokenListener(listeners ...ProjectResourceAccessTokenListener) {
 	d.projectResourceAccessTokenListeners = append(d.projectResourceAccessTokenListeners, listeners...)
 }
 
+// RegisterPushListener registers listeners for push events.
 func (d *Dispatcher) RegisterPushListener(listeners ...PushListener) {
 	d.pushListeners = append(d.pushListeners, listeners...)
 }
 
+// RegisterReleaseListener registers listeners for release events.
 func (d *Dispatcher) RegisterReleaseListener(listeners ...ReleaseListener) {
 	d.releaseListeners = append(d.releaseListeners, listeners...)
 }
 
+// RegisterSnippetCommentListener registers listeners for snippet comment events.
 func (d *Dispatcher) RegisterSnippetCommentListener(listeners ...SnippetCommentListener) {
 	d.snippetCommentListeners = append(d.snippetCommentListeners, listeners...)
 }
 
+// RegisterSubGroupListener registers listeners for subgroup events.
 func (d *Dispatcher) RegisterSubGroupListener(listeners ...SubGroupListener) {
 	d.subGroupListeners = append(d.subGroupListeners, listeners...)
 }
 
+// RegisterTagListener registers listeners for tag push events.
 func (d *Dispatcher) RegisterTagListener(listeners ...TagListener) {
 	d.tagListeners = append(d.tagListeners, listeners...)
 }
 
+// RegisterVulnerabilityListener registers listeners for vulnerability events.
 func (d *Dispatcher) RegisterVulnerabilityListener(listeners ...VulnerabilityListener) {
 	d.vulnerabilityListeners = append(d.vulnerabilityListeners, listeners...)
 }
 
+// RegisterWikiPageListener registers listeners for wiki page events.
 func (d *Dispatcher) RegisterWikiPageListener(listeners ...WikiPageListener) {
 	d.wikiPageListeners = append(d.wikiPageListeners, listeners...)
 }
 
+// Dispatch sends an already parsed GitLab webhook event to registered listeners.
+//
+// Registered middleware runs before listener dispatch. Dispatch returns
+// ErrUnsupportedEvent when event is not one of the supported GitLab webhook
+// event pointer types.
 func (d *Dispatcher) Dispatch(ctx context.Context, event any) error {
 	handler := d.dispatchEvent
 
@@ -335,6 +366,10 @@ func (d *Dispatcher) dispatchEvent(ctx context.Context, event any) error {
 	}
 }
 
+// DispatchWebhook parses a GitLab webhook payload and dispatches the parsed event.
+//
+// eventType selects the GitLab webhook parser branch. Parse errors are returned
+// before middleware or listeners run.
 func (d *Dispatcher) DispatchWebhook(ctx context.Context, eventType gitlab.EventType, payload []byte) error {
 	event, err := gitlab.ParseWebhook(eventType, payload)
 	if err != nil {
@@ -349,14 +384,22 @@ type dispatchRequestOptions struct {
 	maxBodyBytes int64
 }
 
+// DispatchRequestOption configures DispatchRequest.
 type DispatchRequestOption func(*dispatchRequestOptions)
 
+// DispatchRequestWithContext sets the context used for webhook dispatch.
+//
+// By default, DispatchRequest uses req.Context().
 func DispatchRequestWithContext(ctx context.Context) DispatchRequestOption {
 	return func(o *dispatchRequestOptions) {
 		o.ctx = ctx
 	}
 }
 
+// DispatchRequestWithToken requires the GitLab token header to match token.
+//
+// When token is non-empty, DispatchRequest compares it with the X-Gitlab-Token
+// request header and returns ErrInvalidToken on mismatch.
 func DispatchRequestWithToken(token string) DispatchRequestOption {
 	return func(o *dispatchRequestOptions) {
 		o.token = token
@@ -374,6 +417,12 @@ func DispatchRequestWithMaxBodyBytes(max int64) DispatchRequestOption {
 	}
 }
 
+// DispatchRequest validates and dispatches an HTTP GitLab webhook request.
+//
+// The event type is read from the X-Gitlab-Event request header. If a token is
+// configured, the X-Gitlab-Token header is validated before the request body is
+// read. Body read errors, payload size errors, parse errors, and dispatch errors
+// are returned to the caller.
 func (d *Dispatcher) DispatchRequest(req *http.Request, opts ...DispatchRequestOption) error {
 	o := &dispatchRequestOptions{
 		ctx: req.Context(),

--- a/dispatcher.go
+++ b/dispatcher.go
@@ -24,8 +24,9 @@ var (
 // Dispatcher routes parsed GitLab webhook events to registered listeners.
 //
 // Configure a dispatcher before using it to handle events. Once dispatching
-// starts, it is safe to call Dispatch, DispatchWebhook, and DispatchRequest
-// concurrently, but listener and middleware registration must be complete.
+// starts, it is safe to call [Dispatcher.Dispatch],
+// [Dispatcher.DispatchWebhook], and [Dispatcher.DispatchRequest] concurrently,
+// but listener and middleware registration must be complete.
 type Dispatcher struct {
 	buildListeners                      []BuildListener
 	commitCommentListeners              []CommitCommentListener
@@ -53,14 +54,15 @@ type Dispatcher struct {
 	middlewares                         []Middleware
 }
 
-// Option configures a Dispatcher during construction.
+// Option configures a [Dispatcher] during construction.
 type Option func(*Dispatcher)
 
 // RegisterListeners registers listeners during dispatcher construction.
 //
 // Listener and middleware registration is intended to happen before the
 // dispatcher starts handling events. Do not call registration methods
-// concurrently with Dispatch, DispatchWebhook, or DispatchRequest.
+// concurrently with [Dispatcher.Dispatch], [Dispatcher.DispatchWebhook], or
+// [Dispatcher.DispatchRequest].
 func RegisterListeners(listeners ...any) Option {
 	return func(d *Dispatcher) {
 		d.RegisterListeners(listeners...)
@@ -69,7 +71,7 @@ func RegisterListeners(listeners ...any) Option {
 
 // NewDispatcher creates a dispatcher and applies its construction options.
 //
-// A Dispatcher is safe for concurrent dispatch after construction is complete.
+// A [Dispatcher] is safe for concurrent dispatch after construction is complete.
 // Register all listeners and middleware before serving requests; mutating the
 // dispatcher while events are being dispatched is not supported.
 func NewDispatcher(opts ...Option) *Dispatcher {
@@ -300,8 +302,8 @@ func (d *Dispatcher) RegisterWikiPageListener(listeners ...WikiPageListener) {
 
 // Dispatch sends an already parsed GitLab webhook event to registered listeners.
 //
-// Registered middleware runs before listener dispatch. Dispatch returns
-// ErrUnsupportedEvent when event is not one of the supported GitLab webhook
+// Registered [Middleware] runs before listener dispatch. Dispatch returns
+// [ErrUnsupportedEvent] when event is not one of the supported GitLab webhook
 // event pointer types.
 func (d *Dispatcher) Dispatch(ctx context.Context, event any) error {
 	handler := d.dispatchEvent
@@ -369,7 +371,8 @@ func (d *Dispatcher) dispatchEvent(ctx context.Context, event any) error {
 // DispatchWebhook parses a GitLab webhook payload and dispatches the parsed event.
 //
 // eventType selects the GitLab webhook parser branch. Parse errors are returned
-// before middleware or listeners run.
+// before middleware or listeners run. Parsed events are dispatched through
+// [Dispatcher.Dispatch].
 func (d *Dispatcher) DispatchWebhook(ctx context.Context, eventType gitlab.EventType, payload []byte) error {
 	event, err := gitlab.ParseWebhook(eventType, payload)
 	if err != nil {
@@ -384,12 +387,12 @@ type dispatchRequestOptions struct {
 	maxBodyBytes int64
 }
 
-// DispatchRequestOption configures DispatchRequest.
+// DispatchRequestOption configures [Dispatcher.DispatchRequest].
 type DispatchRequestOption func(*dispatchRequestOptions)
 
 // DispatchRequestWithContext sets the context used for webhook dispatch.
 //
-// By default, DispatchRequest uses req.Context().
+// By default, [Dispatcher.DispatchRequest] uses [http.Request.Context].
 func DispatchRequestWithContext(ctx context.Context) DispatchRequestOption {
 	return func(o *dispatchRequestOptions) {
 		o.ctx = ctx
@@ -398,8 +401,8 @@ func DispatchRequestWithContext(ctx context.Context) DispatchRequestOption {
 
 // DispatchRequestWithToken requires the GitLab token header to match token.
 //
-// When token is non-empty, DispatchRequest compares it with the X-Gitlab-Token
-// request header and returns ErrInvalidToken on mismatch.
+// When token is non-empty, [Dispatcher.DispatchRequest] compares it with the
+// X-Gitlab-Token request header and returns [ErrInvalidToken] on mismatch.
 func DispatchRequestWithToken(token string) DispatchRequestOption {
 	return func(o *dispatchRequestOptions) {
 		o.token = token
@@ -409,15 +412,15 @@ func DispatchRequestWithToken(token string) DispatchRequestOption {
 // DispatchRequestWithMaxBodyBytes limits the number of request body bytes read.
 //
 // Values less than or equal to zero disable the limit and keep the default
-// behavior. When the body exceeds max bytes, DispatchRequest returns
-// ErrPayloadTooLarge before parsing or dispatching the webhook.
+// behavior. When the body exceeds max bytes, [Dispatcher.DispatchRequest]
+// returns [ErrPayloadTooLarge] before parsing or dispatching the webhook.
 func DispatchRequestWithMaxBodyBytes(max int64) DispatchRequestOption {
 	return func(o *dispatchRequestOptions) {
 		o.maxBodyBytes = max
 	}
 }
 
-// DispatchRequest validates and dispatches an HTTP GitLab webhook request.
+// DispatchRequest validates and dispatches an HTTP GitLab webhook [http.Request].
 //
 // The event type is read from the X-Gitlab-Event request header. If a token is
 // configured, the X-Gitlab-Token header is validated before the request body is

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,6 @@
+// Package gitlabwebhook dispatches GitLab webhook events to registered listeners.
+//
+// Create a [Dispatcher] with [NewDispatcher], register listeners, and pass
+// incoming HTTP webhook requests to [Dispatcher.DispatchRequest]. Middleware can
+// be added with [WithMiddlewares] or [Dispatcher.Use] before dispatching starts.
+package gitlabwebhook

--- a/listeners.go
+++ b/listeners.go
@@ -6,94 +6,117 @@ import (
 	gitlab "gitlab.com/gitlab-org/api/client-go/v2"
 )
 
+// BuildListener handles GitLab build webhook events.
 type BuildListener interface {
 	OnBuild(ctx context.Context, event *gitlab.BuildEvent) error
 }
 
+// CommitCommentListener handles GitLab commit comment webhook events.
 type CommitCommentListener interface {
 	OnCommitComment(ctx context.Context, event *gitlab.CommitCommentEvent) error
 }
 
+// DeploymentListener handles GitLab deployment webhook events.
 type DeploymentListener interface {
 	OnDeployment(ctx context.Context, event *gitlab.DeploymentEvent) error
 }
 
+// EmojiListener handles GitLab emoji webhook events.
 type EmojiListener interface {
 	OnEmoji(ctx context.Context, event *gitlab.EmojiEvent) error
 }
 
+// FeatureFlagListener handles GitLab feature flag webhook events.
 type FeatureFlagListener interface {
 	OnFeatureFlag(ctx context.Context, event *gitlab.FeatureFlagEvent) error
 }
 
+// GroupResourceAccessTokenListener handles GitLab group resource access token webhook events.
 type GroupResourceAccessTokenListener interface {
 	OnGroupResourceAccessToken(ctx context.Context, event *gitlab.GroupResourceAccessTokenEvent) error
 }
 
+// IssueCommentListener handles GitLab issue comment webhook events.
 type IssueCommentListener interface {
 	OnIssueComment(ctx context.Context, event *gitlab.IssueCommentEvent) error
 }
 
+// IssueListener handles GitLab issue webhook events.
 type IssueListener interface {
 	OnIssue(ctx context.Context, event *gitlab.IssueEvent) error
 }
 
+// JobListener handles GitLab job webhook events.
 type JobListener interface {
 	OnJob(ctx context.Context, event *gitlab.JobEvent) error
 }
 
+// MemberListener handles GitLab member webhook events.
 type MemberListener interface {
 	OnMember(ctx context.Context, event *gitlab.MemberEvent) error
 }
 
+// MilestoneListener handles GitLab milestone webhook events.
 type MilestoneListener interface {
 	OnMilestone(ctx context.Context, event *gitlab.MilestoneWebhookEvent) error
 }
 
+// MergeCommentListener handles GitLab merge request comment webhook events.
 type MergeCommentListener interface {
 	OnMergeComment(ctx context.Context, event *gitlab.MergeCommentEvent) error
 }
 
+// MergeListener handles GitLab merge request webhook events.
 type MergeListener interface {
 	OnMerge(ctx context.Context, event *gitlab.MergeEvent) error
 }
 
+// PipelineListener handles GitLab pipeline webhook events.
 type PipelineListener interface {
 	OnPipeline(ctx context.Context, event *gitlab.PipelineEvent) error
 }
 
+// ProjectListener handles GitLab project webhook events.
 type ProjectListener interface {
 	OnProject(ctx context.Context, event *gitlab.ProjectWebhookEvent) error
 }
 
+// ProjectResourceAccessTokenListener handles GitLab project resource access token webhook events.
 type ProjectResourceAccessTokenListener interface {
 	OnProjectResourceAccessToken(ctx context.Context, event *gitlab.ProjectResourceAccessTokenEvent) error
 }
 
+// PushListener handles GitLab push webhook events.
 type PushListener interface {
 	OnPush(ctx context.Context, event *gitlab.PushEvent) error
 }
 
+// ReleaseListener handles GitLab release webhook events.
 type ReleaseListener interface {
 	OnRelease(ctx context.Context, event *gitlab.ReleaseEvent) error
 }
 
+// SnippetCommentListener handles GitLab snippet comment webhook events.
 type SnippetCommentListener interface {
 	OnSnippetComment(ctx context.Context, event *gitlab.SnippetCommentEvent) error
 }
 
+// SubGroupListener handles GitLab subgroup webhook events.
 type SubGroupListener interface {
 	OnSubGroup(ctx context.Context, event *gitlab.SubGroupEvent) error
 }
 
+// TagListener handles GitLab tag push webhook events.
 type TagListener interface {
 	OnTag(ctx context.Context, event *gitlab.TagEvent) error
 }
 
+// VulnerabilityListener handles GitLab vulnerability webhook events.
 type VulnerabilityListener interface {
 	OnVulnerability(ctx context.Context, event *gitlab.VulnerabilityEvent) error
 }
 
+// WikiPageListener handles GitLab wiki page webhook events.
 type WikiPageListener interface {
 	OnWikiPage(ctx context.Context, event *gitlab.WikiPageEvent) error
 }

--- a/middleware/otel/config.go
+++ b/middleware/otel/config.go
@@ -12,6 +12,8 @@ type config struct {
 }
 
 // Option configures the OpenTelemetry middleware.
+//
+// Nil options are ignored.
 type Option interface {
 	apply(*config)
 }
@@ -23,6 +25,9 @@ func (fn optionFunc) apply(cfg *config) {
 }
 
 // WithTracerProvider configures the tracer provider used by the middleware.
+//
+// If provider is nil, the middleware keeps using the global OpenTelemetry
+// tracer provider.
 func WithTracerProvider(provider trace.TracerProvider) Option {
 	return optionFunc(func(c *config) {
 		if provider != nil {
@@ -32,6 +37,9 @@ func WithTracerProvider(provider trace.TracerProvider) Option {
 }
 
 // WithMeterProvider configures the meter provider used by the middleware.
+//
+// If provider is nil, the middleware keeps using the global OpenTelemetry
+// meter provider.
 func WithMeterProvider(provider metric.MeterProvider) Option {
 	return optionFunc(func(c *config) {
 		if provider != nil {

--- a/middleware/otel/config.go
+++ b/middleware/otel/config.go
@@ -11,7 +11,7 @@ type config struct {
 	meterProvider  metric.MeterProvider
 }
 
-// Option configures the OpenTelemetry middleware.
+// Option configures [Middleware].
 //
 // Nil options are ignored.
 type Option interface {
@@ -26,7 +26,7 @@ func (fn optionFunc) apply(cfg *config) {
 
 // WithTracerProvider configures the tracer provider used by the middleware.
 //
-// If provider is nil, the middleware keeps using the global OpenTelemetry
+// If provider is nil, [Middleware] keeps using the global OpenTelemetry
 // tracer provider.
 func WithTracerProvider(provider trace.TracerProvider) Option {
 	return optionFunc(func(c *config) {
@@ -38,8 +38,8 @@ func WithTracerProvider(provider trace.TracerProvider) Option {
 
 // WithMeterProvider configures the meter provider used by the middleware.
 //
-// If provider is nil, the middleware keeps using the global OpenTelemetry
-// meter provider.
+// If provider is nil, [Middleware] keeps using the global OpenTelemetry meter
+// provider.
 func WithMeterProvider(provider metric.MeterProvider) Option {
 	return optionFunc(func(c *config) {
 		if provider != nil {

--- a/middleware/otel/doc.go
+++ b/middleware/otel/doc.go
@@ -1,0 +1,6 @@
+// Package otel provides OpenTelemetry middleware for GitLab webhook dispatch.
+//
+// Use [Middleware] to add tracing and metrics to a [gitlabwebhook.Dispatcher].
+// Tracer and meter providers can be configured with [WithTracerProvider] and
+// [WithMeterProvider].
+package otel

--- a/middleware/otel/middleware.go
+++ b/middleware/otel/middleware.go
@@ -15,7 +15,10 @@ const (
 	instrumentationName = "github.com/flc1125/go-gitlab-webhook/middleware/otel/v3"
 )
 
-// Middleware returns middleware that traces webhook event dispatch.
+// Middleware returns middleware that traces and records metrics for webhook event dispatch.
+//
+// The middleware creates a span for each dispatched event, records errors on the
+// span, and records event metrics with the configured meter provider.
 func Middleware(opts ...Option) gitlabwebhook.Middleware {
 	cfg := newConfig(opts...)
 	tracer := cfg.tracerProvider.Tracer(

--- a/middleware/otel/middleware.go
+++ b/middleware/otel/middleware.go
@@ -15,7 +15,8 @@ const (
 	instrumentationName = "github.com/flc1125/go-gitlab-webhook/middleware/otel/v3"
 )
 
-// Middleware returns middleware that traces and records metrics for webhook event dispatch.
+// Middleware returns a [gitlabwebhook.Middleware] that traces and records
+// metrics for webhook event dispatch.
 //
 // The middleware creates a span for each dispatched event, records errors on the
 // span, and records event metrics with the configured meter provider.

--- a/middleware/otel/version.go
+++ b/middleware/otel/version.go
@@ -1,5 +1,6 @@
 package otel
 
+// Version returns the middleware module version.
 func Version() string {
 	return "3.0.2"
 }

--- a/version.go
+++ b/version.go
@@ -1,5 +1,6 @@
 package gitlabwebhook
 
+// Version returns the module version.
 func Version() string {
 	return "3.0.2"
 }


### PR DESCRIPTION
## Summary
Improve the pkg.go.dev experience by completing exported API comments for the dispatcher, listeners, request options, and OpenTelemetry middleware.

## Changes
- Add Go doc comments for exported dispatcher APIs, listener interfaces, registration methods, request options, and version helpers
- Add focused Go doc links for key entry points, errors, request types, and OpenTelemetry configuration APIs
- Add package-level documentation for the root module and the OTel middleware module

## Motivation
- Public API docs should be navigable and understandable directly from pkg.go.dev without relying on README context alone

## Testing
- `gofmt`
- `git diff --check`
- `make test`
- Checked local pkgsite rendering for `github.com/flc1125/go-gitlab-webhook/v3`
- Checked local pkgsite rendering for `github.com/flc1125/go-gitlab-webhook/middleware/otel/v3`